### PR TITLE
nft payment flow: move multiple db steps into single exposed db tx

### DIFF
--- a/store-api-server/migrations/1649861170-nft_editions_locked_v3.sql
+++ b/store-api-server/migrations/1649861170-nft_editions_locked_v3.sql
@@ -1,0 +1,39 @@
+-- Migration: nft_editions_locked_v3
+-- Created at: 2022-04-13 16:46:10
+-- ====  UP  ====
+
+BEGIN;
+
+ALTER FUNCTION nft_editions_locked RENAME TO __nft_editions_locked_v2;
+CREATE FUNCTION nft_editions_locked(INT)
+  RETURNS TABLE(reserved BIGINT, owned BIGINT)
+AS $$
+  SELECT
+    count(cart_nfts) FILTER (WHERE nft_order IS NULL)
+    + count(order_nfts) FILTER (WHERE nft_order IS NOT NULL) AS reserved,
+    (SELECT count(1) FROM mtm_kanvas_user_nft WHERE nft_id = $1) AS owned
+  FROM cart_session AS cart
+  LEFT JOIN mtm_cart_session_nft AS cart_nfts
+    ON  cart_nfts.cart_session_id = cart.id
+    AND cart_nfts.nft_id = $1
+
+  LEFT JOIN nft_order
+    ON nft_order.id = cart.order_id
+  LEFT JOIN mtm_nft_order_nft AS order_nfts
+    ON  order_nfts.nft_order_id = nft_order.id
+    AND order_nfts.nft_id = $1
+  LEFT JOIN payment
+    ON  payment.nft_order_id = nft_order.id
+    AND payment.status IN ('created', 'processing')
+$$ LANGUAGE SQL;
+
+COMMIT;
+
+-- ==== DOWN ====
+
+BEGIN;
+
+DROP FUNCTION nft_editions_locked(INT);
+ALTER FUNCTION __nft_editions_locked_v2 RENAME TO nft_editions_locked;
+
+COMMIT;

--- a/store-api-server/migrations/1649861170-nft_editions_locked_v3.sql
+++ b/store-api-server/migrations/1649861170-nft_editions_locked_v3.sql
@@ -9,8 +9,8 @@ CREATE FUNCTION nft_editions_locked(INT)
   RETURNS TABLE(reserved BIGINT, owned BIGINT)
 AS $$
   SELECT
-    count(cart_nfts) FILTER (WHERE nft_order IS NULL)
-    + count(order_nfts) FILTER (WHERE nft_order IS NOT NULL) AS reserved,
+    count(cart_nfts) FILTER (WHERE payment IS NULL)
+    + count(order_nfts) FILTER (WHERE payment IS NOT NULL) AS reserved,
     (SELECT count(1) FROM mtm_kanvas_user_nft WHERE nft_id = $1) AS owned
   FROM cart_session AS cart
   LEFT JOIN mtm_cart_session_nft AS cart_nfts

--- a/store-api-server/migrations/1649861172-unique_payment_nft_order_id.sql
+++ b/store-api-server/migrations/1649861172-unique_payment_nft_order_id.sql
@@ -1,0 +1,19 @@
+-- Migration: unique_payment_nft_order_id
+-- Created at: 2022-04-13 16:46:12
+-- ====  UP  ====
+
+BEGIN;
+
+ALTER TABLE payment ADD CONSTRAINT payment_nft_order_id_uniq UNIQUE(nft_order_id);
+ALTER TABLE mtm_nft_category ADD CONSTRAINT mtm_nft_category_uniq UNIQUE(nft_id, nft_category_id);
+
+COMMIT;
+
+-- ==== DOWN ====
+
+BEGIN;
+
+ALTER TABLE payment DROP CONSTRAINT payment_nft_order_id_uniq;
+ALTER TABLE mtm_nft_category DROP CONSTRAINT mtm_nft_category_uniq;
+
+COMMIT;

--- a/store-api-server/src/db.module.ts
+++ b/store-api-server/src/db.module.ts
@@ -1,10 +1,11 @@
 import { Logger, Module, Inject } from '@nestjs/common';
 import { assertEnv } from './utils';
 import { PG_CONNECTION } from './constants';
-import { Client, types } from 'pg';
+import { Client, types, PoolClient } from 'pg';
 import * as Pool from 'pg-pool';
 
 export type DbPool = Pool<Client>;
+export type DbTransaction = PoolClient;
 
 // Read postgres TIMESTAMP WITHOUT TIME ZONE values as UTC+0 Date
 types.setTypeParser(
@@ -58,5 +59,22 @@ export class DbModule {
     await this.w.dbPool.end();
     this.w.dbPool = undefined;
     Logger.log('db connection closed');
+  }
+}
+
+export async function withTransaction<ResTy>(
+  dbPool: DbPool,
+  f: (dbTx: DbTransaction) => Promise<ResTy>,
+): Promise<ResTy> {
+  const dbTx = await dbPool.connect();
+  try {
+    const res = await f(dbTx);
+    await dbTx.query(`COMMIT`);
+    return res;
+  } catch (err: any) {
+    await dbTx.query(`ROLLBACK`);
+    throw err;
+  } finally {
+    dbTx.release();
   }
 }

--- a/store-api-server/src/nft/service/nft.service.ts
+++ b/store-api-server/src/nft/service/nft.service.ts
@@ -122,13 +122,12 @@ SELECT $1, UNNEST($2::INTEGER[])
     return await withTransaction(this.conn, async (dbTx: DbTransaction) => {
       await insert(dbTx);
       await uploadToIpfs(dbTx);
-
-      await dbTx.query(`COMMIT`);
-      Logger.log(`Created new NFT ${newNft.id}`);
     }).catch((err: any) => {
       Logger.error(`failed to publish nft (id=${newNft.id}), err: ${err}`);
       throw err;
     });
+
+    Logger.log(`Created new NFT ${newNft.id}`);
   }
 
   async search(str: string): Promise<NftEntity[]> {

--- a/store-api-server/src/nft/service/nft.service.ts
+++ b/store-api-server/src/nft/service/nft.service.ts
@@ -19,6 +19,7 @@ import {
 import { sleep } from 'src/utils';
 import { cryptoUtils } from 'sotez';
 import { IpfsService } from './ipfs.service';
+import { DbTransaction, withTransaction } from 'src/db.module';
 
 @Injectable()
 export class NftService {
@@ -118,22 +119,16 @@ SELECT $1, UNNEST($2::INTEGER[])
 
     await validate();
 
-    const dbTx = await this.conn.connect();
-    try {
-      await dbTx.query(`BEGIN`);
-
+    return await withTransaction(this.conn, async (dbTx: DbTransaction) => {
       await insert(dbTx);
       await uploadToIpfs(dbTx);
 
       await dbTx.query(`COMMIT`);
       Logger.log(`Created new NFT ${newNft.id}`);
-    } catch (err: any) {
+    }).catch((err: any) => {
       Logger.error(`failed to publish nft (id=${newNft.id}), err: ${err}`);
-      await dbTx.query(`ROLLBACK`);
       throw err;
-    } finally {
-      dbTx.release();
-    }
+    });
   }
 
   async search(str: string): Promise<NftEntity[]> {

--- a/store-api-server/src/payment/service/payment.service.ts
+++ b/store-api-server/src/payment/service/payment.service.ts
@@ -46,6 +46,7 @@ export class PaymentService {
     PaymentStatus.FAILED,
     PaymentStatus.SUCCEEDED,
     PaymentStatus.CANCELED,
+    PaymentStatus.TIMED_OUT,
   ];
 
   constructor(
@@ -487,9 +488,9 @@ RETURNING nft_id
   }
 
   // Test functions
-  async getPaymentIdForLatestUserOrder(
+  async getPaymentForLatestUserOrder(
     userId: number,
-  ): Promise<{ payment_id: string; order_id: number; status: PaymentStatus }> {
+  ): Promise<{ paymentId: string; orderId: number; status: PaymentStatus }> {
     const qryRes = await this.conn.query(
       `
 SELECT payment_id, status, nft_order.id as order_id
@@ -509,8 +510,8 @@ ORDER BY payment.id DESC
     );
 
     return {
-      payment_id: qryRes.rows[0]['payment_id'],
-      order_id: qryRes.rows[0]['order_id'],
+      paymentId: qryRes.rows[0]['payment_id'],
+      orderId: qryRes.rows[0]['order_id'],
       status: qryRes.rows[0]['status'],
     };
   }

--- a/store-api-server/src/utils.ts
+++ b/store-api-server/src/utils.ts
@@ -2,6 +2,7 @@ import { Ok, Err } from 'ts-results';
 import { HttpException } from '@nestjs/common';
 import { Response } from 'express';
 import { Cache } from 'cache-manager';
+import { Lock } from 'async-await-mutex-lock';
 
 export async function wrapCache<T>(
   cache: Cache,
@@ -78,4 +79,17 @@ export function sleep(ms: number) {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
+}
+
+export async function withKeyLocked<LockKeyTy, ResTy>(
+  lock: Lock<LockKeyTy>,
+  key: LockKeyTy,
+  f: () => Promise<ResTy>,
+): Promise<ResTy> {
+  await lock.acquire(key);
+  try {
+    return await f();
+  } finally {
+    lock.release(key);
+  }
 }

--- a/store-api-server/test/coverage/summary.txt
+++ b/store-api-server/test/coverage/summary.txt
@@ -1,128 +1,128 @@
 
--------------------------------|---------|----------|---------|---------|-----------------------------------------------------------------------------------
+-------------------------------|---------|----------|---------|---------|---------------------------------------------------------------------------------------
 
-File                           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                                                 
+File                           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                                                     
 
--------------------------------|---------|----------|---------|---------|-----------------------------------------------------------------------------------
+-------------------------------|---------|----------|---------|---------|---------------------------------------------------------------------------------------
 
-All files                      |   81.84 |    61.31 |   82.14 |   80.41 |                                                                                   
+All files                      |   81.63 |    60.49 |   82.14 |   80.18 |                                                                                       
 
- src                           |   67.64 |    45.45 |   63.15 |   66.15 |                                                                                   
+ src                           |   67.64 |    45.45 |   63.15 |   66.15 |                                                                                       
 
-  app.module.ts                |     100 |      100 |     100 |     100 |                                                                                   
+  app.module.ts                |     100 |      100 |     100 |     100 |                                                                                       
 
-  constants.ts                 |     100 |     87.5 |     100 |     100 | 22                                                                                
+  constants.ts                 |     100 |     87.5 |     100 |     100 | 22                                                                                    
 
-  db.module.ts                 |    90.9 |        0 |     100 |   90.32 | 31,53-56                                                                          
+  db.module.ts                 |    90.9 |        0 |     100 |   90.32 | 31,53-56                                                                              
 
-  main.ts                      |       0 |        0 |       0 |       0 | 1-21                                                                              
+  main.ts                      |       0 |        0 |       0 |       0 | 1-21                                                                                  
 
-  s3.service.ts                |   53.33 |        0 |      50 |   46.15 | 15-35                                                                             
+  s3.service.ts                |   53.33 |        0 |      50 |   46.15 | 15-35                                                                                 
 
-  utils.ts                     |    47.5 |    33.33 |      50 |    47.5 | 24,29-30,39,47-53,65-75,89-93                                                     
+  utils.ts                     |    47.5 |    33.33 |      50 |    47.5 | 24,29-30,39,47-53,65-75,89-93                                                         
 
- src/auth-provider             |     100 |      100 |     100 |     100 |                                                                                   
+ src/auth-provider             |     100 |      100 |     100 |     100 |                                                                                       
 
-  auth-provider.module.ts      |     100 |      100 |     100 |     100 |                                                                                   
+  auth-provider.module.ts      |     100 |      100 |     100 |     100 |                                                                                       
 
- src/auth-provider/entity      |     100 |      100 |     100 |     100 |                                                                                   
+ src/auth-provider/entity      |     100 |      100 |     100 |     100 |                                                                                       
 
-  auth-provider.entity.ts      |     100 |      100 |     100 |     100 |                                                                                   
+  auth-provider.entity.ts      |     100 |      100 |     100 |     100 |                                                                                       
 
- src/auth-provider/service     |   66.66 |      100 |       0 |      50 |                                                                                   
+ src/auth-provider/service     |   66.66 |      100 |       0 |      50 |                                                                                       
 
-  auth-provider.service.ts     |   66.66 |      100 |       0 |      50 | 7-10                                                                              
+  auth-provider.service.ts     |   66.66 |      100 |       0 |      50 | 7-10                                                                                  
 
- src/authentication            |     100 |      100 |     100 |     100 |                                                                                   
+ src/authentication            |     100 |      100 |     100 |     100 |                                                                                       
 
-  authentication.module.ts     |     100 |      100 |     100 |     100 |                                                                                   
+  authentication.module.ts     |     100 |      100 |     100 |     100 |                                                                                       
 
- src/authentication/controller |   76.92 |    77.77 |   83.33 |      75 |                                                                                   
+ src/authentication/controller |   76.92 |    77.77 |   83.33 |      75 |                                                                                       
 
-  authentication.controller.ts |   76.92 |    77.77 |   83.33 |      75 | 25-34,68-71                                                                       
+  authentication.controller.ts |   76.92 |    77.77 |   83.33 |      75 | 25-34,68-71                                                                           
 
- src/authentication/guards     |   92.85 |       25 |     100 |      90 |                                                                                   
+ src/authentication/guards     |   92.85 |       25 |     100 |      90 |                                                                                       
 
-  jwt-auth.guard.ts            |   92.85 |       25 |     100 |      90 | 19                                                                                
+  jwt-auth.guard.ts            |   92.85 |       25 |     100 |      90 | 19                                                                                    
 
- src/authentication/service    |   85.36 |       75 |    87.5 |   84.61 |                                                                                   
+ src/authentication/service    |   85.36 |       75 |    87.5 |   84.61 |                                                                                       
 
-  authentication.service.ts    |   85.36 |       75 |    87.5 |   84.61 | 58-63,74,130                                                                      
+  authentication.service.ts    |   85.36 |       75 |    87.5 |   84.61 | 58-63,74,130                                                                          
 
- src/authentication/strategy   |     100 |      100 |     100 |     100 |                                                                                   
+ src/authentication/strategy   |     100 |      100 |     100 |     100 |                                                                                       
 
-  jwt-auth.strategy.ts         |     100 |      100 |     100 |     100 |                                                                                   
+  jwt-auth.strategy.ts         |     100 |      100 |     100 |     100 |                                                                                       
 
- src/category                  |     100 |      100 |     100 |     100 |                                                                                   
+ src/category                  |     100 |      100 |     100 |     100 |                                                                                       
 
-  category.module.ts           |     100 |      100 |     100 |     100 |                                                                                   
+  category.module.ts           |     100 |      100 |     100 |     100 |                                                                                       
 
- src/category/controller       |     100 |      100 |     100 |     100 |                                                                                   
+ src/category/controller       |     100 |      100 |     100 |     100 |                                                                                       
 
-  category.controller.ts       |     100 |      100 |     100 |     100 |                                                                                   
+  category.controller.ts       |     100 |      100 |     100 |     100 |                                                                                       
 
- src/category/service          |   93.33 |      100 |     100 |   92.85 |                                                                                   
+ src/category/service          |   93.33 |      100 |     100 |   92.85 |                                                                                       
 
-  category.service.ts          |   93.33 |      100 |     100 |   92.85 | 90-91                                                                             
+  category.service.ts          |   93.33 |      100 |     100 |   92.85 | 90-91                                                                                 
 
- src/decoraters                |     100 |       50 |     100 |     100 |                                                                                   
+ src/decoraters                |     100 |       50 |     100 |     100 |                                                                                       
 
-  proxied_throttler.ts         |     100 |       50 |     100 |     100 | 7                                                                                 
+  proxied_throttler.ts         |     100 |       50 |     100 |     100 | 7                                                                                     
 
-  user.decorator.ts            |     100 |      100 |     100 |     100 |                                                                                   
+  user.decorator.ts            |     100 |      100 |     100 |     100 |                                                                                       
 
- src/middleware                |   83.01 |    68.75 |    87.5 |   80.85 |                                                                                   
+ src/middleware                |   83.01 |    68.75 |    87.5 |   80.85 |                                                                                       
 
-  cookie_session.ts            |     100 |      100 |     100 |     100 |                                                                                   
+  cookie_session.ts            |     100 |      100 |     100 |     100 |                                                                                       
 
-  logger.ts                    |   78.04 |    66.66 |      80 |   75.67 | 20-33                                                                             
+  logger.ts                    |   78.04 |    66.66 |      80 |   75.67 | 20-33                                                                                 
 
- src/mock                      |     100 |      100 |     100 |     100 |                                                                                   
+ src/mock                      |     100 |      100 |     100 |     100 |                                                                                       
 
-  cache.module.ts              |     100 |      100 |     100 |     100 |                                                                                   
+  cache.module.ts              |     100 |      100 |     100 |     100 |                                                                                       
 
-  db.module.ts                 |     100 |      100 |     100 |     100 |                                                                                   
+  db.module.ts                 |     100 |      100 |     100 |     100 |                                                                                       
 
- src/nft                       |   91.11 |       50 |   63.63 |   89.74 |                                                                                   
+ src/nft                       |   91.11 |       50 |   63.63 |   89.74 |                                                                                       
 
-  nft.module.ts                |     100 |      100 |     100 |     100 |                                                                                   
+  nft.module.ts                |     100 |      100 |     100 |     100 |                                                                                       
 
-  params.ts                    |   88.88 |       50 |   63.63 |    87.5 | 31,51,56,61                                                                       
+  params.ts                    |   88.88 |       50 |   63.63 |    87.5 | 31,51,56,61                                                                           
 
- src/nft/controller            |   97.56 |     87.5 |     100 |   97.36 |                                                                                   
+ src/nft/controller            |   97.56 |     87.5 |     100 |   97.36 |                                                                                       
 
-  nft.controller.ts            |   97.56 |     87.5 |     100 |   97.36 | 69                                                                                
+  nft.controller.ts            |   97.56 |     87.5 |     100 |   97.36 | 69                                                                                    
 
- src/nft/service               |   71.85 |    47.05 |   68.29 |   70.68 |                                                                                   
+ src/nft/service               |   71.21 |    47.05 |   68.29 |      70 |                                                                                       
 
-  ipfs.service.ts              |    36.2 |       10 |   21.42 |   33.92 | 16-25,45-77,85-171,182-188                                                        
+  ipfs.service.ts              |    36.2 |       10 |   21.42 |   33.92 | 16-25,45-77,85-171,182-188                                                            
 
-  mint.service.ts              |   80.64 |      100 |   83.33 |   79.31 | 35,53-63,74-89                                                                    
+  mint.service.ts              |   80.64 |      100 |   83.33 |   79.31 | 35,53-63,74-89                                                                        
 
-  nft.service.ts               |   88.18 |       75 |   95.23 |   87.73 | 48,109-117,129-130,177-181,192,246-247,388-389                                    
+  nft.service.ts               |   87.15 |       75 |   95.23 |   86.66 | 48,109-117,126-130,176-180,191,245-246,387-388                                        
 
- src/payment                   |     100 |      100 |     100 |     100 |                                                                                   
+ src/payment                   |     100 |      100 |     100 |     100 |                                                                                       
 
-  payment.module.ts            |     100 |      100 |     100 |     100 |                                                                                   
+  payment.module.ts            |     100 |      100 |     100 |     100 |                                                                                       
 
- src/payment/controller        |   48.14 |        0 |   33.33 |      44 |                                                                                   
+ src/payment/controller        |   48.14 |        0 |   33.33 |      44 |                                                                                       
 
-  payment.controller.ts        |   48.14 |        0 |   33.33 |      44 | 35-62,70-77                                                                       
+  payment.controller.ts        |   48.14 |        0 |   33.33 |      44 | 35-62,70-77                                                                           
 
- src/payment/service           |   82.17 |    65.62 |    86.2 |    81.6 |                                                                                   
+ src/payment/service           |   81.39 |    59.37 |    86.2 |    80.8 |                                                                                       
 
-  payment.service.ts           |   82.17 |    65.62 |    86.2 |    81.6 | 75-79,121-122,138,162,214-217,227,239-248,280-283,323-326,388,395-400,437,447-450 
+  payment.service.ts           |   81.39 |    59.37 |    86.2 |    80.8 | 76-80,122-123,139,163,172,215-218,228,240-249,281-284,324-327,389,396-401,438,448-451 
 
- src/user                      |     100 |      100 |     100 |     100 |                                                                                   
+ src/user                      |     100 |      100 |     100 |     100 |                                                                                       
 
-  user.module.ts               |     100 |      100 |     100 |     100 |                                                                                   
+  user.module.ts               |     100 |      100 |     100 |     100 |                                                                                       
 
- src/user/controller           |   86.56 |       75 |     100 |   85.71 |                                                                                   
+ src/user/controller           |   86.56 |       75 |     100 |   85.71 |                                                                                       
 
-  user.controller.ts           |   86.56 |       75 |     100 |   85.71 | 67,112-113,149-152,174,178,190-193                                                
+  user.controller.ts           |   86.56 |       75 |     100 |   85.71 | 67,112-113,149-152,174,178,190-193                                                    
 
- src/user/service              |   91.73 |    67.85 |     100 |   91.45 |                                                                                   
+ src/user/service              |   91.73 |    67.85 |     100 |   91.45 |                                                                                       
 
-  user.service.ts              |   91.73 |    67.85 |     100 |   91.45 | 74,97-102,199,295,344,350                                                         
+  user.service.ts              |   91.73 |    67.85 |     100 |   91.45 | 74,97-102,199,295,344,350                                                             
 
--------------------------------|---------|----------|---------|---------|-----------------------------------------------------------------------------------
+-------------------------------|---------|----------|---------|---------|---------------------------------------------------------------------------------------

--- a/store-api-server/test/coverage/summary.txt
+++ b/store-api-server/test/coverage/summary.txt
@@ -1,128 +1,128 @@
 
--------------------------------|---------|----------|---------|---------|-----------------------------------------------------------------------
+-------------------------------|---------|----------|---------|---------|-----------------------------------------------------------------------------------
 
-File                           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                                     
+File                           | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                                                 
 
--------------------------------|---------|----------|---------|---------|-----------------------------------------------------------------------
+-------------------------------|---------|----------|---------|---------|-----------------------------------------------------------------------------------
 
-All files                      |   81.59 |    61.37 |   83.42 |   80.16 |                                                                       
+All files                      |   81.84 |    61.31 |   82.14 |   80.41 |                                                                                   
 
- src                           |   67.21 |    45.45 |    64.7 |   65.51 |                                                                       
+ src                           |   67.64 |    45.45 |   63.15 |   66.15 |                                                                                   
 
-  app.module.ts                |     100 |      100 |     100 |     100 |                                                                       
+  app.module.ts                |     100 |      100 |     100 |     100 |                                                                                   
 
-  constants.ts                 |     100 |     87.5 |     100 |     100 | 22                                                                    
+  constants.ts                 |     100 |     87.5 |     100 |     100 | 22                                                                                
 
-  db.module.ts                 |    87.5 |        0 |     100 |   86.36 | 30,52-55                                                              
+  db.module.ts                 |    90.9 |        0 |     100 |   90.32 | 31,53-56                                                                          
 
-  main.ts                      |       0 |        0 |       0 |       0 | 1-21                                                                  
+  main.ts                      |       0 |        0 |       0 |       0 | 1-21                                                                              
 
-  s3.service.ts                |   53.33 |        0 |      50 |   46.15 | 15-35                                                                 
+  s3.service.ts                |   53.33 |        0 |      50 |   46.15 | 15-35                                                                             
 
-  utils.ts                     |   51.42 |    33.33 |   55.55 |   51.42 | 23,28-29,38,46-52,64-74                                               
+  utils.ts                     |    47.5 |    33.33 |      50 |    47.5 | 24,29-30,39,47-53,65-75,89-93                                                     
 
- src/auth-provider             |     100 |      100 |     100 |     100 |                                                                       
+ src/auth-provider             |     100 |      100 |     100 |     100 |                                                                                   
 
-  auth-provider.module.ts      |     100 |      100 |     100 |     100 |                                                                       
+  auth-provider.module.ts      |     100 |      100 |     100 |     100 |                                                                                   
 
- src/auth-provider/entity      |     100 |      100 |     100 |     100 |                                                                       
+ src/auth-provider/entity      |     100 |      100 |     100 |     100 |                                                                                   
 
-  auth-provider.entity.ts      |     100 |      100 |     100 |     100 |                                                                       
+  auth-provider.entity.ts      |     100 |      100 |     100 |     100 |                                                                                   
 
- src/auth-provider/service     |   66.66 |      100 |       0 |      50 |                                                                       
+ src/auth-provider/service     |   66.66 |      100 |       0 |      50 |                                                                                   
 
-  auth-provider.service.ts     |   66.66 |      100 |       0 |      50 | 7-10                                                                  
+  auth-provider.service.ts     |   66.66 |      100 |       0 |      50 | 7-10                                                                              
 
- src/authentication            |     100 |      100 |     100 |     100 |                                                                       
+ src/authentication            |     100 |      100 |     100 |     100 |                                                                                   
 
-  authentication.module.ts     |     100 |      100 |     100 |     100 |                                                                       
+  authentication.module.ts     |     100 |      100 |     100 |     100 |                                                                                   
 
- src/authentication/controller |   76.92 |    77.77 |   83.33 |      75 |                                                                       
+ src/authentication/controller |   76.92 |    77.77 |   83.33 |      75 |                                                                                   
 
-  authentication.controller.ts |   76.92 |    77.77 |   83.33 |      75 | 25-34,68-71                                                           
+  authentication.controller.ts |   76.92 |    77.77 |   83.33 |      75 | 25-34,68-71                                                                       
 
- src/authentication/guards     |   92.85 |       25 |     100 |      90 |                                                                       
+ src/authentication/guards     |   92.85 |       25 |     100 |      90 |                                                                                   
 
-  jwt-auth.guard.ts            |   92.85 |       25 |     100 |      90 | 19                                                                    
+  jwt-auth.guard.ts            |   92.85 |       25 |     100 |      90 | 19                                                                                
 
- src/authentication/service    |   85.36 |       75 |    87.5 |   84.61 |                                                                       
+ src/authentication/service    |   85.36 |       75 |    87.5 |   84.61 |                                                                                   
 
-  authentication.service.ts    |   85.36 |       75 |    87.5 |   84.61 | 58-63,74,130                                                          
+  authentication.service.ts    |   85.36 |       75 |    87.5 |   84.61 | 58-63,74,130                                                                      
 
- src/authentication/strategy   |     100 |      100 |     100 |     100 |                                                                       
+ src/authentication/strategy   |     100 |      100 |     100 |     100 |                                                                                   
 
-  jwt-auth.strategy.ts         |     100 |      100 |     100 |     100 |                                                                       
+  jwt-auth.strategy.ts         |     100 |      100 |     100 |     100 |                                                                                   
 
- src/category                  |     100 |      100 |     100 |     100 |                                                                       
+ src/category                  |     100 |      100 |     100 |     100 |                                                                                   
 
-  category.module.ts           |     100 |      100 |     100 |     100 |                                                                       
+  category.module.ts           |     100 |      100 |     100 |     100 |                                                                                   
 
- src/category/controller       |     100 |      100 |     100 |     100 |                                                                       
+ src/category/controller       |     100 |      100 |     100 |     100 |                                                                                   
 
-  category.controller.ts       |     100 |      100 |     100 |     100 |                                                                       
+  category.controller.ts       |     100 |      100 |     100 |     100 |                                                                                   
 
- src/category/service          |   93.33 |      100 |     100 |   92.85 |                                                                       
+ src/category/service          |   93.33 |      100 |     100 |   92.85 |                                                                                   
 
-  category.service.ts          |   93.33 |      100 |     100 |   92.85 | 90-91                                                                 
+  category.service.ts          |   93.33 |      100 |     100 |   92.85 | 90-91                                                                             
 
- src/decoraters                |     100 |       50 |     100 |     100 |                                                                       
+ src/decoraters                |     100 |       50 |     100 |     100 |                                                                                   
 
-  proxied_throttler.ts         |     100 |       50 |     100 |     100 | 7                                                                     
+  proxied_throttler.ts         |     100 |       50 |     100 |     100 | 7                                                                                 
 
-  user.decorator.ts            |     100 |      100 |     100 |     100 |                                                                       
+  user.decorator.ts            |     100 |      100 |     100 |     100 |                                                                                   
 
- src/middleware                |   83.01 |    68.75 |    87.5 |   80.85 |                                                                       
+ src/middleware                |   83.01 |    68.75 |    87.5 |   80.85 |                                                                                   
 
-  cookie_session.ts            |     100 |      100 |     100 |     100 |                                                                       
+  cookie_session.ts            |     100 |      100 |     100 |     100 |                                                                                   
 
-  logger.ts                    |   78.04 |    66.66 |      80 |   75.67 | 20-33                                                                 
+  logger.ts                    |   78.04 |    66.66 |      80 |   75.67 | 20-33                                                                             
 
- src/mock                      |     100 |      100 |     100 |     100 |                                                                       
+ src/mock                      |     100 |      100 |     100 |     100 |                                                                                   
 
-  cache.module.ts              |     100 |      100 |     100 |     100 |                                                                       
+  cache.module.ts              |     100 |      100 |     100 |     100 |                                                                                   
 
-  db.module.ts                 |     100 |      100 |     100 |     100 |                                                                       
+  db.module.ts                 |     100 |      100 |     100 |     100 |                                                                                   
 
- src/nft                       |   91.11 |       50 |   63.63 |   89.74 |                                                                       
+ src/nft                       |   91.11 |       50 |   63.63 |   89.74 |                                                                                   
 
-  nft.module.ts                |     100 |      100 |     100 |     100 |                                                                       
+  nft.module.ts                |     100 |      100 |     100 |     100 |                                                                                   
 
-  params.ts                    |   88.88 |       50 |   63.63 |    87.5 | 31,51,56,61                                                           
+  params.ts                    |   88.88 |       50 |   63.63 |    87.5 | 31,51,56,61                                                                       
 
- src/nft/controller            |   97.56 |     87.5 |     100 |   97.36 |                                                                       
+ src/nft/controller            |   97.56 |     87.5 |     100 |   97.36 |                                                                                   
 
-  nft.controller.ts            |   97.56 |     87.5 |     100 |   97.36 | 69                                                                    
+  nft.controller.ts            |   97.56 |     87.5 |     100 |   97.36 | 69                                                                                
 
- src/nft/service               |   71.78 |    47.05 |   69.23 |   70.61 |                                                                       
+ src/nft/service               |   71.85 |    47.05 |   68.29 |   70.68 |                                                                                   
 
-  ipfs.service.ts              |    36.2 |       10 |   21.42 |   33.92 | 16-25,45-77,85-171,182-188                                            
+  ipfs.service.ts              |    36.2 |       10 |   21.42 |   33.92 | 16-25,45-77,85-171,182-188                                                        
 
-  mint.service.ts              |   80.64 |      100 |   83.33 |   79.31 | 35,53-63,74-89                                                        
+  mint.service.ts              |   80.64 |      100 |   83.33 |   79.31 | 35,53-63,74-89                                                                    
 
-  nft.service.ts               |   87.61 |       75 |     100 |   87.15 | 47,108-116,131-133,182-186,197,251-252,393-394                        
+  nft.service.ts               |   88.18 |       75 |   95.23 |   87.73 | 48,109-117,129-130,177-181,192,246-247,388-389                                    
 
- src/payment                   |     100 |      100 |     100 |     100 |                                                                       
+ src/payment                   |     100 |      100 |     100 |     100 |                                                                                   
 
-  payment.module.ts            |     100 |      100 |     100 |     100 |                                                                       
+  payment.module.ts            |     100 |      100 |     100 |     100 |                                                                                   
 
- src/payment/controller        |   44.11 |        0 |   33.33 |   40.62 |                                                                       
+ src/payment/controller        |   48.14 |        0 |   33.33 |      44 |                                                                                   
 
-  payment.controller.ts        |   44.11 |        0 |   33.33 |   40.62 | 41-68,76-101                                                          
+  payment.controller.ts        |   48.14 |        0 |   33.33 |      44 | 35-62,70-77                                                                       
 
- src/payment/service           |    82.7 |    70.37 |   94.73 |   82.17 |                                                                       
+ src/payment/service           |   82.17 |    65.62 |    86.2 |    81.6 |                                                                                   
 
-  payment.service.ts           |    82.7 |    70.37 |   94.73 |   82.17 | 70-74,102,118-127,166-169,204-208,234,269-274,285,332-336,384,394-398 
+  payment.service.ts           |   82.17 |    65.62 |    86.2 |    81.6 | 75-79,121-122,138,162,214-217,227,239-248,280-283,323-326,388,395-400,437,447-450 
 
- src/user                      |     100 |      100 |     100 |     100 |                                                                       
+ src/user                      |     100 |      100 |     100 |     100 |                                                                                   
 
-  user.module.ts               |     100 |      100 |     100 |     100 |                                                                       
+  user.module.ts               |     100 |      100 |     100 |     100 |                                                                                   
 
- src/user/controller           |   86.56 |       75 |     100 |   85.71 |                                                                       
+ src/user/controller           |   86.56 |       75 |     100 |   85.71 |                                                                                   
 
-  user.controller.ts           |   86.56 |       75 |     100 |   85.71 | 66,111-112,148-151,175,187-190,197                                    
+  user.controller.ts           |   86.56 |       75 |     100 |   85.71 | 67,112-113,149-152,174,178,190-193                                                
 
- src/user/service              |   90.69 |    65.21 |     100 |    90.4 |                                                                       
+ src/user/service              |   91.73 |    67.85 |     100 |   91.45 |                                                                                   
 
-  user.service.ts              |   90.69 |    65.21 |     100 |    90.4 | 67,90-95,191,284,332-333,336-337                                      
+  user.service.ts              |   91.73 |    67.85 |     100 |   91.45 | 74,97-102,199,295,344,350                                                         
 
--------------------------------|---------|----------|---------|---------|-----------------------------------------------------------------------
+-------------------------------|---------|----------|---------|---------|-----------------------------------------------------------------------------------


### PR DESCRIPTION
There were some corner cases exposed, regarding when an NFT should
remain locked (reserved). These corner cases were exposed in part due to multiple
db operations not being run in a in db tx. 

And this was done this way to allow exposing each step's function publicly so that the e2e tests can target these functions individually.

But really the only reason the tests wanted to target the step's functions individually was to omit the call to stripe. I changed these functions to be private to the PaymentService class, and it only exposes 1 function `createPayment` that calls them in sequence. The tests can prevent the calling of Stripe by supplying the `PaymentProvider.TEST` value to `createPayment`. Only 1 test was really not possible anymore, which only applied the first step, I've removed this test.

Note: in general I changed some naming in the `payment.service.ts`, hope it doesn't make the PR review a hassle.

## 
Additionally added some generic functions for wrapping database transactions into convenient lambdas (for better code readability but also for preventing some bugs that have already happened more than once, like forgetting to clean up the db transaction).

I will introduce the same `withTransaction` generic function in admin-api-server in a subsequent PR.