### PR TITLE
allow running store-api without requiring proving ownership of login addresses

### DIFF
--- a/store-api-server/src/authentication/controller/authentication.controller.ts
+++ b/store-api-server/src/authentication/controller/authentication.controller.ts
@@ -52,7 +52,19 @@ export class AuthenticationController {
 
   @Post('login')
   async login(@Body() user: UserEntity): Promise<any> {
-    return this.authService.login(user);
+    try {
+      return await this.authService.login(user);
+    } catch (err: any) {
+      if (!(err instanceof HttpException)) {
+        throw err;
+      }
+
+      if (err.getStatus() === 400) {
+        await this.register(user);
+
+        return await this.authService.login(user);
+      }
+    }
   }
 
   @Post('register')

--- a/store-api-server/src/authentication/service/authentication.service.ts
+++ b/store-api-server/src/authentication/service/authentication.service.ts
@@ -5,6 +5,7 @@ import { ITokenPayload } from '../../interfaces/token.interface.js';
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { Result } from 'ts-results';
 import ts_results from 'ts-results';
+import { SIGNED_LOGIN_ENABLED } from '../../constants.js';
 const { Ok } = ts_results;
 
 import { createRequire } from 'module';
@@ -38,20 +39,22 @@ export class AuthenticationService {
     }
     const user = userRes.val;
 
-    if (
-      user.signedPayload !== undefined &&
-      userData.signedPayload !== undefined
-    ) {
-      await this.verifyPassword(userData.signedPayload, user.signedPayload);
-
-      return this.getCookieWithJwtToken(
-        {
-          id: user.id,
-          userAddress: user.userAddress,
-        },
-        user,
-      );
+    if (SIGNED_LOGIN_ENABLED) {
+      if (
+        user.signedPayload !== undefined &&
+        userData.signedPayload !== undefined
+      ) {
+        await this.verifyPassword(userData.signedPayload, user.signedPayload);
+      }
     }
+
+    return this.getCookieWithJwtToken(
+      {
+        id: user.id,
+        userAddress: user.userAddress,
+      },
+      user,
+    );
   }
 
   public async getLoggedUser(
@@ -83,14 +86,12 @@ export class AuthenticationService {
   }
 
   public async register(user: UserEntity): Promise<any> {
-    const hashedsignedKanvasPayload: string = await bcrypt.hash(
-      user.signedPayload,
-      10,
-    );
-    const createdUser = await this.userService.create({
-      ...user,
-      signedPayload: hashedsignedKanvasPayload,
-    });
+    let newUser = { ...user };
+    if (SIGNED_LOGIN_ENABLED) {
+      newUser.signedPayload = await bcrypt.hash(user.signedPayload, 10);
+    }
+
+    const createdUser = await this.userService.create(newUser);
 
     createdUser.signedPayload = undefined;
 

--- a/store-api-server/src/constants.ts
+++ b/store-api-server/src/constants.ts
@@ -50,3 +50,6 @@ export const PAYMENT_PROMISE_DEADLINE_MILLI_SECS = Number(
 export const ORDER_EXPIRATION_MILLI_SECS = Number(
   process.env['ORDER_EXPIRATION_MILLI_SECS'] || 3600 * 1000,
 );
+
+export const SIGNED_LOGIN_ENABLED =
+  (process.env['SIGNED_LOGIN_ENABLED'] || 'no') === 'yes';


### PR DESCRIPTION
Added a new env variable SIGNED_LOGIN_ENABLED:
- when set to yes, it requires login w/ a signed payload that proves ownership of the address.
- otherwise, we don't care about proving ownership. anyone can login with whichever address they want.

This allows running in a mode where users dont need to sign a payload on login, simplifying this UX. It also means that anyone can login as anyone else, but this would simply mean they're going to purchase NFTs to an tezos address they don't own themselves.

Furthermore, unrelated, I simplified the POST /auth/login call when doing this for a not yet existing account. Now rather than sending a 400, and requiring a frontend to call the POST /auth/register endpoint, the API simply registers the account and logs into that immediately in the same single POST /auth/login call. 