### PR TITLE
Justin/dto types

### DIFF
--- a/store-api-server/src/authentication/service/authentication.d.ts
+++ b/store-api-server/src/authentication/service/authentication.d.ts
@@ -1,0 +1,6 @@
+export interface IAuthentication {
+  id: number;
+  userAddress: string;
+  token: string;
+  maxAge: string;
+}

--- a/store-api-server/src/authentication/service/authentication.service.ts
+++ b/store-api-server/src/authentication/service/authentication.service.ts
@@ -9,15 +9,11 @@ import { SIGNED_LOGIN_ENABLED } from '../../constants.js';
 const { Ok } = ts_results;
 
 import { createRequire } from 'module';
+
+import type { IAuthentication } from './authentication.js';
+
 const require = createRequire(import.meta.url);
 const bcrypt = require('bcrypt');
-
-interface IAuthentication {
-  id: number;
-  userAddress: string;
-  token: string;
-  maxAge: string;
-}
 
 @Injectable()
 export class AuthenticationService {

--- a/store-api-server/src/nft/entity/nft.entity.ts
+++ b/store-api-server/src/nft/entity/nft.entity.ts
@@ -1,4 +1,4 @@
-import { CategoryEntity } from '../../category/entity/category.entity.js';
+import type { CategoryEntity } from '../../category/entity/category.entity.js';
 
 export interface NftEntity {
   id: number;

--- a/store-api-server/src/user/entity/user.entity.ts
+++ b/store-api-server/src/user/entity/user.entity.ts
@@ -1,4 +1,4 @@
-import { NftEntity, NftEntityPage } from '../../nft/entity/nft.entity.js';
+import type { NftEntity, NftEntityPage } from '../../nft/entity/nft.entity.js';
 
 export interface UserEntity {
   id: number;


### PR DESCRIPTION
In order to reuse ("some" at this point not "all") types in the frontend (the API response types), I needed to move `IAuthentication` into it's own file. `IAuthentication`'s type could be computed from the exported `AuthenticationService` with:

```ts
type IAuthentication = ReturnType<InstanceType<typeof AuthenticationService>>
```

But the build would still fail on the frontend due to not finding types from e.g. ` '@nestjs/jwt'` (first import in `store-api-server/src/authentication/service/authentication.service.ts`). So I needed to move it in a "types only file".

I also needed to add `import type` instead of `import` to any types currently being used in: https://github.com/tzConnectBerlin/sowvital/pull/141

This is because we are now using:

```
    "importsNotUsedAsValues": "error"
```

in tsconfig. It would be nice if BE adds this too but I did not include it in this PR (would require updates to `import` statements which are only importing types):

https://github.com/tzConnectBerlin/sowvital/pull/141/files#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0R17
