### PR TITLE
allow sidestepping the rate limiter for SSR

### DIFF
--- a/store-api-server/src/constants.ts
+++ b/store-api-server/src/constants.ts
@@ -66,3 +66,6 @@ export const SIGNED_LOGIN_ENABLED: boolean =
 export const CART_MAX_ITEMS: number = Number(
   process.env['CART_MAX_ITEMS'] || 10,
 );
+
+export const RATE_LIMITLESS_SECRET: string | undefined =
+  process.env['RATE_LIMITLESS_SECRET'];

--- a/store-api-server/src/decoraters/proxied_throttler.ts
+++ b/store-api-server/src/decoraters/proxied_throttler.ts
@@ -1,9 +1,17 @@
 import { ThrottlerGuard } from '@nestjs/throttler';
 import { Injectable } from '@nestjs/common';
+import { v4 as uuidv4 } from 'uuid';
+import { RATE_LIMITLESS_SECRET } from '../constants.js';
 
 @Injectable()
 export class ProxiedThrottlerGuard extends ThrottlerGuard {
   protected getTracker(req: Record<string, any>): string {
+    if (
+      typeof RATE_LIMITLESS_SECRET === 'string' &&
+      req.headers['rate-limitless'] === RATE_LIMITLESS_SECRET
+    ) {
+      return uuidv4();
+    }
     return req.ips.length ? req.ips[0] : req.ip;
   }
 }

--- a/store-api-server/src/middleware/logger.ts
+++ b/store-api-server/src/middleware/logger.ts
@@ -8,7 +8,11 @@ import {
 } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { Cache } from 'cache-manager';
-import { CACHE_SIZE, BEHIND_PROXY } from '../constants.js';
+import {
+  CACHE_SIZE,
+  BEHIND_PROXY,
+  RATE_LIMITLESS_SECRET,
+} from '../constants.js';
 
 @Injectable()
 export class StatsLogger {
@@ -54,6 +58,13 @@ export class LoggerMiddleware implements NestMiddleware {
       realIp,
       `sess:${cookieSession}`,
     ];
+
+    if (
+      typeof RATE_LIMITLESS_SECRET === 'string' &&
+      request.headers['rate-limitless'] === RATE_LIMITLESS_SECRET
+    ) {
+      fields.push('rate-limitless');
+    }
 
     this.logger.log(`>> ${fields.join(' ')}`);
 


### PR DESCRIPTION
Unfortunately the library that we use for rate limiting does not provide a clean way to disable the rate limiting based on a request header.

Therefore a slightly hacky approach that just generates a unique id with uuidv4 everytime a request comes that has this secret provided. That will effectively sidestep the rate limiting because it's always done based on a fresh count (because of the fresh uuidv4).

I think in the future we should maybe consider another solution than this library for rate limiting.