### PR TITLE
Beacon fix post ithacanet=>ghostnet upgrade

### DIFF
--- a/admin-api-server/test/coverage/summary.txt
+++ b/admin-api-server/test/coverage/summary.txt
@@ -1,142 +1,143 @@
 
---------------------------|---------|----------|---------|---------|-----------------------------------------------
+--------------------------|---------|----------|---------|---------|-----------------------------------------------------
 
-File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                             
+File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
 
---------------------------|---------|----------|---------|---------|-----------------------------------------------
+--------------------------|---------|----------|---------|---------|-----------------------------------------------------
 
-All files                 |   88.92 |    70.83 |   90.25 |   87.86 |                                               
+All files                 |   87.15 |    65.38 |    89.1 |   85.95 |
 
- src                      |   82.31 |    69.44 |   85.71 |   81.29 |                                               
+ src                      |   80.66 |    67.56 |   85.71 |   79.57 |
+>>>>>>> Stashed changes
 
-  app.module.ts           |     100 |      100 |     100 |     100 |                                               
+  app.module.ts           |     100 |      100 |     100 |     100 |
 
-  constants.ts            |     100 |       80 |     100 |     100 | 22-26                                         
+  constants.ts            |     100 |       80 |     100 |     100 | 25-29
 
-  db.module.ts            |   87.09 |        0 |     100 |    86.2 | 32,50,72-75                                   
+  db.module.ts            |   87.09 |        0 |     100 |    86.2 | 32,50,72-75
 
-  db_mock.module.ts       |     100 |      100 |     100 |     100 |                                               
+  db_mock.module.ts       |     100 |      100 |     100 |     100 |
 
-  main.ts                 |       0 |        0 |       0 |       0 | 1-32                                          
+  main.ts                 |       0 |        0 |       0 |       0 | 1-40
 
-  utils.ts                |   90.74 |       85 |   85.71 |   90.38 | 7,12-13,29,112                                
+  utils.ts                |   90.74 |       85 |   85.71 |   90.38 | 7,12-13,29,112
 
- src/analytics            |      85 |      100 |      25 |   83.33 |                                               
+ src/analytics            |      85 |      100 |      25 |   83.33 |
 
-  analytics.module.ts     |     100 |      100 |     100 |     100 |                                               
+  analytics.module.ts     |     100 |      100 |     100 |     100 |
 
-  params.ts               |      75 |      100 |      25 |      75 | 11,16,21                                      
+  params.ts               |      75 |      100 |      25 |      75 | 11,16,21
 
- src/analytics/controller |     100 |    83.33 |     100 |     100 |                                               
+ src/analytics/controller |     100 |    83.33 |     100 |     100 |
 
-  analytics.controller.ts |     100 |    83.33 |     100 |     100 | 124                                           
+  analytics.controller.ts |     100 |    83.33 |     100 |     100 | 124
 
- src/analytics/entity     |     100 |      100 |     100 |     100 |                                               
+ src/analytics/entity     |     100 |      100 |     100 |     100 |
 
-  analytics.entity.ts     |     100 |      100 |     100 |     100 |                                               
+  analytics.entity.ts     |     100 |      100 |     100 |     100 |
 
- src/analytics/service    |     100 |      100 |     100 |     100 |                                               
+ src/analytics/service    |     100 |      100 |     100 |     100 |
 
-  analytics.service.ts    |     100 |      100 |     100 |     100 |                                               
+  analytics.service.ts    |     100 |      100 |     100 |     100 |
 
- src/auth                 |     100 |      100 |     100 |     100 |                                               
+ src/auth                 |     100 |      100 |     100 |     100 |
 
-  auth.module.ts          |     100 |      100 |     100 |     100 |                                               
+  auth.module.ts          |     100 |      100 |     100 |     100 |
 
- src/auth/controller      |     100 |      100 |     100 |     100 |                                               
+ src/auth/controller      |     100 |      100 |     100 |     100 |
 
-  auth.controller.ts      |     100 |      100 |     100 |     100 |                                               
+  auth.controller.ts      |     100 |      100 |     100 |     100 |
 
- src/auth/guard           |     100 |      100 |     100 |     100 |                                               
+ src/auth/guard           |     100 |      100 |     100 |     100 |
 
-  jwt-auth.guard.ts       |     100 |      100 |     100 |     100 |                                               
+  jwt-auth.guard.ts       |     100 |      100 |     100 |     100 |
 
- src/auth/service         |     100 |      100 |     100 |     100 |                                               
+ src/auth/service         |     100 |      100 |     100 |     100 |
 
-  auth.service.ts         |     100 |      100 |     100 |     100 |                                               
+  auth.service.ts         |     100 |      100 |     100 |     100 |
 
- src/auth/strategy        |   96.15 |      100 |     100 |   95.45 |                                               
+ src/auth/strategy        |   96.15 |      100 |     100 |   95.45 |
 
-  jwt.strategy.ts         |    92.3 |      100 |     100 |    90.9 | 21                                            
+  jwt.strategy.ts         |    92.3 |      100 |     100 |    90.9 | 21
 
-  local.strategy.ts       |     100 |      100 |     100 |     100 |                                               
+  local.strategy.ts       |     100 |      100 |     100 |     100 |
 
- src/category             |     100 |      100 |     100 |     100 |                                               
+ src/category             |     100 |      100 |     100 |     100 |
 
-  category.module.ts      |     100 |      100 |     100 |     100 |                                               
+  category.module.ts      |     100 |      100 |     100 |     100 |
 
- src/category/controller  |     100 |      100 |     100 |     100 |                                               
+ src/category/controller  |     100 |      100 |     100 |     100 |
 
-  category.controller.ts  |     100 |      100 |     100 |     100 |                                               
+  category.controller.ts  |     100 |      100 |     100 |     100 |
 
- src/category/service     |   83.33 |      100 |     100 |      80 |                                               
+ src/category/service     |   83.33 |      100 |     100 |      80 |
 
-  category.service.ts     |   83.33 |      100 |     100 |      80 | 35-36                                         
+  category.service.ts     |   83.33 |      100 |     100 |      80 | 35-36
 
- src/decoraters           |     100 |       50 |     100 |     100 |                                               
+ src/decoraters           |     100 |       50 |     100 |     100 |
 
-  proxied_throttler.ts    |     100 |       50 |     100 |     100 | 7                                             
+  proxied_throttler.ts    |     100 |       50 |     100 |     100 | 7
 
-  user.decorator.ts       |     100 |      100 |     100 |     100 |                                               
+  user.decorator.ts       |     100 |      100 |     100 |     100 |
 
- src/middleware           |     100 |    61.53 |     100 |     100 |                                               
+ src/middleware           |     100 |    61.53 |     100 |     100 |
 
-  cookie_session.ts       |     100 |      100 |     100 |     100 |                                               
+  cookie_session.ts       |     100 |      100 |     100 |     100 |
 
-  logger.ts               |     100 |    58.33 |     100 |     100 | 12-13                                         
+  logger.ts               |     100 |    58.33 |     100 |     100 | 12-13
 
- src/nft                  |     100 |       75 |     100 |     100 |                                               
+ src/nft                  |     100 |       75 |     100 |     100 |
 
-  nft.module.ts           |     100 |      100 |     100 |     100 |                                               
+  nft.module.ts           |     100 |      100 |     100 |     100 |
 
-  params.ts               |     100 |       75 |     100 |     100 | 17                                            
+  params.ts               |     100 |       75 |     100 |     100 | 17
 
- src/nft/controller       |   83.72 |    33.33 |      80 |   82.92 |                                               
+ src/nft/controller       |   67.85 |     7.14 |   72.72 |   66.66 |
 
-  nft.controller.ts       |   83.72 |    33.33 |      80 |   82.92 | 32-41,122-123                                 
+  nft.controller.ts       |   67.85 |     7.14 |   72.72 |   66.66 | 33-51,58,133-149
 
- src/nft/service          |   82.06 |    62.16 |    90.9 |   81.56 |                                               
+ src/nft/service          |   80.74 |    62.16 |   88.23 |   80.21 |
 
-  nft.service.ts          |    84.7 |    63.88 |   93.54 |   84.43 | 59-68,202-203,228,255,315-316,330-351,436,521 
+  nft.service.ts          |   83.23 |    63.88 |   90.62 |   82.94 | 63-72,89-91,212-213,238,265,325-326,340-361,446,531
 
-  s3.service.ts           |      50 |        0 |      50 |   41.66 | 14-37                                         
+  s3.service.ts           |      50 |        0 |      50 |   41.66 | 14-37
 
- src/pipes                |      70 |       80 |     100 |    62.5 |                                               
+ src/pipes                |      70 |       80 |     100 |    62.5 |
 
-  ParseJSONArrayPipe.ts   |      70 |       80 |     100 |    62.5 | 13,17-18                                      
+  ParseJSONArrayPipe.ts   |      70 |       80 |     100 |    62.5 | 13,17-18
 
- src/role                 |      96 |       60 |     100 |   94.73 |                                               
+ src/role                 |      96 |       60 |     100 |   94.73 |
 
-  role.decorator.ts       |     100 |      100 |     100 |     100 |                                               
+  role.decorator.ts       |     100 |      100 |     100 |     100 |
 
-  role.guard.ts           |    92.3 |       60 |     100 |      90 | 15                                            
+  role.guard.ts           |    92.3 |       60 |     100 |      90 | 15
 
-  role.module.ts          |     100 |      100 |     100 |     100 |                                               
+  role.module.ts          |     100 |      100 |     100 |     100 |
 
- src/role/controller      |   77.77 |      100 |       0 |   71.42 |                                               
+ src/role/controller      |   77.77 |      100 |       0 |   71.42 |
 
-  role.controller.ts      |   77.77 |      100 |       0 |   71.42 | 8,13                                          
+  role.controller.ts      |   77.77 |      100 |       0 |   71.42 | 8,13
 
- src/role/entities        |     100 |      100 |     100 |     100 |                                               
+ src/role/entities        |     100 |      100 |     100 |     100 |
 
-  role.entity.ts          |     100 |      100 |     100 |     100 |                                               
+  role.entity.ts          |     100 |      100 |     100 |     100 |
 
- src/role/service         |    62.5 |        0 |      60 |   53.84 |                                               
+ src/role/service         |    62.5 |        0 |      60 |   53.84 |
 
-  role.service.ts         |    62.5 |        0 |      60 |   53.84 | 10-14,40-46                                   
+  role.service.ts         |    62.5 |        0 |      60 |   53.84 | 10-14,40-46
 
- src/user                 |     100 |       75 |     100 |     100 |                                               
+ src/user                 |     100 |       75 |     100 |     100 |
 
-  params.ts               |     100 |       75 |     100 |     100 | 12-24                                         
+  params.ts               |     100 |       75 |     100 |     100 | 12-24
 
-  user.module.ts          |     100 |      100 |     100 |     100 |                                               
+  user.module.ts          |     100 |      100 |     100 |     100 |
 
- src/user/controller      |     100 |      100 |     100 |     100 |                                               
+ src/user/controller      |     100 |      100 |     100 |     100 |
 
-  user.controller.ts      |     100 |      100 |     100 |     100 |                                               
+  user.controller.ts      |     100 |      100 |     100 |     100 |
 
- src/user/service         |   89.55 |     87.5 |     100 |    88.7 |                                               
+ src/user/service         |   89.55 |     87.5 |     100 |    88.7 |
 
-  user.service.ts         |   89.55 |     87.5 |     100 |    88.7 | 56-63,210-212,229                             
+  user.service.ts         |   89.55 |     87.5 |     100 |    88.7 | 56-63,210-212,229
 
---------------------------|---------|----------|---------|---------|-----------------------------------------------
+--------------------------|---------|----------|---------|---------|-----------------------------------------------------

--- a/shell.nix
+++ b/shell.nix
@@ -1,13 +1,11 @@
-with (import <nixpkgs> {});
-mkShell {
-  buildInputs = [
-    ripgrep
-    postgresql
-    jq
-    httpie
-  ];
+{ pkgs ? import <nixpkgs> {} }:
+with pkgs;
 
-  shellHook = ''
-    PATH=$PATH:~/.yarn/bin
-  '';
+let
+
+in mkShell {
+  buildInputs = [
+    yarn
+    nodejs-18_x
+  ];
 }

--- a/store-front/package.json
+++ b/store-front/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@airgap/beacon-sdk": "^3.0.0",
+    "@airgap/beacon-sdk": "^3.1.3",
     "@emotion/react": "^11.4.1",
     "@emotion/styled": "^11.0.0",
     "@material-ui/core": "^4.12.3",
@@ -18,7 +18,7 @@
     "@storybook/addon-docs": "^6.3.8",
     "@stripe/react-stripe-js": "^1.7.0",
     "@stripe/stripe-js": "^1.22.0",
-    "@taquito/beacon-wallet": "^12.1.1",
+    "@taquito/beacon-wallet": "^13.0.1",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/store-front/src/global.ts
+++ b/store-front/src/global.ts
@@ -3,8 +3,8 @@ import { Networks } from 'kukai-embed';
 
 export const RPC_URL =
     process.env.REACT_APP_RPC_URL ?? 'http://hangzhounet.tzconnect.berlin/';
-export const NETWORK: keyof typeof NetworkType = 'ITHACANET';
-export const KUKAI_NETWORK: keyof typeof Networks | 'ithacanet' = 'ithacanet';
+export const NETWORK: keyof typeof NetworkType = 'GHOSTNET';
+export const KUKAI_NETWORK: keyof typeof Networks | 'ghostnet' = 'ghostnet';
 
 export const PROFILE_PICTURES_ENABLED: boolean =
     (process.env.REACT_APP_PROFILE_PICTURES_ENABLED || 'no') === 'yes';


### PR DESCRIPTION
The latest ithacanet=>ghostnet upgrade required updates in the beacon-sdk.