### PR TITLE
Admin api: upgrade from CommonJS to ESM

### DIFF
--- a/admin-api-server/package.json
+++ b/admin-api-server/package.json
@@ -5,6 +5,7 @@
   "author": "",
   "private": true,
   "license": "UNLICENSED",
+  "type": "module",
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "nest build",
@@ -14,7 +15,7 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/src/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-    "seed": "NODE_PATH=. ts-node ./src/seeds/index.ts",
+    "seed": "node ./dist/src/seeds/index",
     "test": "./script/test"
   },
   "dependencies": {
@@ -27,7 +28,10 @@
     "@nestjs/schedule": "1.0.2",
     "@nestjs/throttler": "^2.0.0",
     "@types/bcrypt": "^5.0.0",
+    "@types/cron": "^1.7.3",
     "@types/passport-local": "^1.0.34",
+    "@types/uuid": "^8.3.4",
+    "@types/validator": "^13.7.2",
     "async-await-mutex-lock": "^1.0.7",
     "aws-sdk": "^2.1046.0",
     "bcrypt": "^5.0.1",
@@ -86,21 +90,19 @@
       "node_modules",
       "<rootDir>"
     ],
+    "extensionsToTreatAsEsm": [".ts"],
+    "globals": {
+    "ts-jest": {
+        "useESM": true
+      }
+    },
+    "moduleNameMapper": {
+    "^(\\.{1,2}/.*)\\.js$": "$1"
+    },
     "moduleFileExtensions": [
       "js",
       "json",
       "ts"
-    ],
-    "testPathIgnorePatterns": [
-      "<rootDir>/node_modules/",
-      "<rootDir>/lib/"
-    ],
-    "modulePathIgnorePatterns": [
-      "<rootDir>/lib/"
-    ],
-    "transformIgnorePatterns": [
-      "<rootDir>/node_modules/",
-      "<rootDir>/lib/"
     ],
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
@@ -108,10 +110,6 @@
     },
     "collectCoverageFrom": [
       "src/**/{!(nft_mock.service),}.ts"
-    ],
-    "coveragePathIgnorePatterns": [
-      "<rootDir>/node_modules/",
-      "<rootDir>/src/seeds"
     ],
     "coverageDirectory": "test/coverage",
     "testEnvironment": "node"

--- a/admin-api-server/package.json
+++ b/admin-api-server/package.json
@@ -13,9 +13,9 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/src/main",
+    "start:prod": "node dist/src/main.js",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-    "seed": "node ./dist/src/seeds/index",
+    "seed": "node ./dist/src/seeds/index.js",
     "test": "./script/test"
   },
   "dependencies": {
@@ -86,18 +86,19 @@
     "typescript": "^4.3.5"
   },
   "jest": {
+    "preset": "ts-jest/presets/default-esm",
     "moduleDirectories": [
       "node_modules",
       "<rootDir>"
     ],
     "extensionsToTreatAsEsm": [".ts"],
     "globals": {
-    "ts-jest": {
+      "ts-jest": {
         "useESM": true
       }
     },
     "moduleNameMapper": {
-    "^(\\.{1,2}/.*)\\.js$": "$1"
+      "^(\\.{1,2}/.*)\\.js$": "$1"
     },
     "moduleFileExtensions": [
       "js",
@@ -108,10 +109,16 @@
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
+    "transformIgnorePatterns": [
+        "<rootDir>/node_modules/",
+        "<rootDir>/stm-lib/",
+        "/kanvas/lib/api-lib/"
+    ],
     "collectCoverageFrom": [
       "src/**/{!(nft_mock.service),}.ts"
     ],
     "coverageDirectory": "test/coverage",
+    "coverageProvider": "v8",
     "testEnvironment": "node"
   }
 }

--- a/admin-api-server/script/test
+++ b/admin-api-server/script/test
@@ -2,6 +2,11 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR/..
 
+(
+    cd stm-lib
+    yarn build
+)
+
 set -a
 . .env.test
 set +a
@@ -50,17 +55,19 @@ echo "starting the store api in the background"
 # enabling job control with set -m here, this will enforce a new process group
 # for the following background spawned store api, which in turn will allow
 # proper kill of all child processes by kill on process group id.
-mv $SCRIPT_DIR/../../store-api-server/.env $SCRIPT_DIR/../../store-api-server/.env_disabled_during_tests
 set -m
 (
     cd $SCRIPT_DIR/../../store-api-server
+    yarn build || exit 1
+
     set -a
     . .env.test
-    store_env_exec yarn run start >/dev/null 2>&1
+
+    DOTENV_CONFIG_PATH=.env.test store_env_exec yarn run start:prod >/dev/null 2>&1
 ) &
 store_api_pid=$!
 set +m
-trap "docker kill $db_docker; kill -- -$store_api_pid; mv $SCRIPT_DIR/../../store-api-server/.env_disabled_during_tests $SCRIPT_DIR/../../store-api-server/.env" EXIT
+trap "docker kill $db_docker; kill -- -$store_api_pid" EXIT
 
 yarn run seed || exit 1
 
@@ -72,7 +79,7 @@ done
 echo "running tests.."
 
 mkdir -p test/coverage
-jest "$@" --coverage | tee test/coverage/summary.txt || exit 1
+LOG_LEVEL=warning node --experimental-vm-modules node_modules/.bin/jest "$@" --coverage | tee test/coverage/summary.txt || exit 1
 sed -n '/^-----/,$p' test/coverage/summary.txt > test/coverage/summary_.txt
 head -n 4 test/coverage/summary_.txt | awk -F '|' '{print $2 $3 $4 $5}'
 sed 's/^/\n/' test/coverage/summary_.txt > test/coverage/summary.txt

--- a/admin-api-server/src/analytics/analytics.module.ts
+++ b/admin-api-server/src/analytics/analytics.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
-import { AnalyticsController } from './controller/analytics.controller';
-import { AnalyticsService } from './service/analytics.service';
-import { DbModule } from 'src/db.module';
+import { AnalyticsController } from './controller/analytics.controller.js';
+import { AnalyticsService } from './service/analytics.service.js';
+import { DbModule } from '../db.module.js';
 import { CurrencyModule } from 'kanvas-api-lib';
 
 @Module({

--- a/admin-api-server/src/analytics/controller/analytics.controller.spec.ts
+++ b/admin-api-server/src/analytics/controller/analytics.controller.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AnalyticsController } from './analytics.controller';
 import { AnalyticsService } from '../service/analytics.service';
-import { DbMockModule } from 'src/db_mock.module';
+import { DbMockModule } from '../../db_mock.module';
 import { mockedRatesProvider, CurrencyService } from 'kanvas-api-lib';
 
 describe('AnalyticsController', () => {

--- a/admin-api-server/src/analytics/controller/analytics.controller.ts
+++ b/admin-api-server/src/analytics/controller/analytics.controller.ts
@@ -11,19 +11,19 @@ import {
   MetricParams,
   Resolution,
   Activity,
-} from '../entity/analytics.entity';
-import { ParseJSONArrayPipe } from 'src/pipes/ParseJSONArrayPipe';
-import { AnalyticsService } from '../service/analytics.service';
-import { enumFromStringValue } from 'src/utils';
-import { RolesDecorator } from 'src/role/role.decorator';
-import { Roles } from 'src/role/entities/role.entity';
-import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
-import { RolesGuard } from 'src/role/role.guard';
-import { ActivityFilterParams, ActivityFilters } from '../params';
+} from '../entity/analytics.entity.js';
+import { ParseJSONArrayPipe } from '../../pipes/ParseJSONArrayPipe.js';
+import { AnalyticsService } from '../service/analytics.service.js';
+import { enumFromStringValue } from '../../utils.js';
+import { RolesDecorator } from '../../role/role.decorator.js';
+import { Roles } from '../../role/entities/role.entity.js';
+import { JwtAuthGuard } from '../../auth/guard/jwt-auth.guard.js';
+import { RolesGuard } from '../../role/role.guard.js';
+import { ActivityFilterParams, ActivityFilters } from '../params.js';
 import {
   queryParamsToPaginationParams,
   validatePaginationParams,
-} from 'src/utils';
+} from '../../utils.js';
 
 @Controller('analytics')
 export class AnalyticsController {

--- a/admin-api-server/src/analytics/params.ts
+++ b/admin-api-server/src/analytics/params.ts
@@ -4,7 +4,7 @@ import {
   parseStringArray,
   parseNumberParam,
   PaginationParams,
-} from 'src/utils';
+} from '../utils.js';
 
 export class ActivityFilters {
   @IsArray()

--- a/admin-api-server/src/analytics/service/analytics.service.spec.ts
+++ b/admin-api-server/src/analytics/service/analytics.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AnalyticsService } from './analytics.service';
-import { DbMockModule } from 'src/db_mock.module';
+import { DbMockModule } from '../../db_mock.module';
 import { mockedRatesProvider, CurrencyService } from 'kanvas-api-lib';
 
 describe('AnalyticsService', () => {

--- a/admin-api-server/src/analytics/service/analytics.service.ts
+++ b/admin-api-server/src/analytics/service/analytics.service.ts
@@ -4,9 +4,9 @@ import {
   MetricEntity,
   MetricParams,
   Activity,
-} from '../entity/analytics.entity';
-import { PG_CONNECTION_STORE_REPLICATION } from '../../constants';
-import { ActivityFilterParams } from '../params';
+} from '../entity/analytics.entity.js';
+import { PG_CONNECTION_STORE_REPLICATION } from '../../constants.js';
+import { ActivityFilterParams } from '../params.js';
 import { BASE_CURRENCY, CurrencyService } from 'kanvas-api-lib';
 
 @Injectable()

--- a/admin-api-server/src/app.module.ts
+++ b/admin-api-server/src/app.module.ts
@@ -1,18 +1,19 @@
 import { APP_GUARD } from '@nestjs/core';
 import { MiddlewareConsumer, Module } from '@nestjs/common';
 import { ThrottlerModule } from '@nestjs/throttler';
-import { AuthModule } from './auth/auth.module';
-import { UserModule } from './user/user.module';
-import { NftModule } from './nft/nft.module';
-import { CategoryModule } from './category/category.module';
-import { AnalyticsModule } from './analytics/analytics.module';
-import { RoleModule } from './role/role.module';
-import { LoggerMiddleware } from './middleware/logger';
-import { CookieSessionMiddleware } from './middleware/cookie_session';
-import { ProxiedThrottlerGuard } from './decoraters/proxied_throttler';
-import { RATE_LIMIT_WINDOW_SECS, RATE_LIMIT } from 'src/constants';
 import { ScheduleModule } from '@nestjs/schedule';
 import { CurrencyModule } from 'kanvas-api-lib';
+
+import { AuthModule } from './auth/auth.module.js';
+import { UserModule } from './user/user.module.js';
+import { NftModule } from './nft/nft.module.js';
+import { CategoryModule } from './category/category.module.js';
+import { AnalyticsModule } from './analytics/analytics.module.js';
+import { RoleModule } from './role/role.module.js';
+import { LoggerMiddleware } from './middleware/logger.js';
+import { CookieSessionMiddleware } from './middleware/cookie_session.js';
+import { ProxiedThrottlerGuard } from './decoraters/proxied_throttler.js';
+import { RATE_LIMIT_WINDOW_SECS, RATE_LIMIT } from './constants.js';
 
 @Module({
   imports: [

--- a/admin-api-server/src/auth/auth.module.ts
+++ b/admin-api-server/src/auth/auth.module.ts
@@ -1,11 +1,11 @@
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
-import { UserModule } from 'src/user/user.module';
-import { AuthController } from './controller/auth.controller';
-import { AuthService } from './service/auth.service';
-import { JwtStrategy } from './strategy/jwt.strategy';
-import { LocalStrategy } from './strategy/local.strategy';
+import { UserModule } from '../user/user.module.js';
+import { AuthController } from './controller/auth.controller.js';
+import { AuthService } from './service/auth.service.js';
+import { JwtStrategy } from './strategy/jwt.strategy.js';
+import { LocalStrategy } from './strategy/local.strategy.js';
 
 @Module({
   providers: [AuthService, JwtStrategy, LocalStrategy],

--- a/admin-api-server/src/auth/controller/auth.controller.ts
+++ b/admin-api-server/src/auth/controller/auth.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Post, Request, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
-import { AuthService } from '../service/auth.service';
+import { AuthService } from '../service/auth.service.js';
 
 @Controller()
 export class AuthController {

--- a/admin-api-server/src/auth/service/auth.service.ts
+++ b/admin-api-server/src/auth/service/auth.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
-import { UserEntity } from 'src/user/entities/user.entity';
-import { UserService } from 'src/user/service/user.service';
+import { UserEntity } from '../../user/entities/user.entity.js';
+import { UserService } from '../../user/service/user.service.js';
 
 @Injectable()
 export class AuthService {
@@ -21,7 +21,10 @@ export class AuthService {
   async validateUser(email: string, pass: string): Promise<UserEntity | null> {
     const user = await this.usersService.findOneByEmail(email);
     if (typeof user !== 'undefined') {
-      const hasValidPassword = await this.validatePassword(pass, user.password);
+      const hasValidPassword = await this.validatePassword(
+        pass,
+        user.password!,
+      );
       if (hasValidPassword) {
         return user;
       }

--- a/admin-api-server/src/auth/strategy/jwt.strategy.ts
+++ b/admin-api-server/src/auth/strategy/jwt.strategy.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { PassportStrategy } from '@nestjs/passport';
-import { UserService } from 'src/user/service/user.service';
+import { UserService } from '../../user/service/user.service.js';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {

--- a/admin-api-server/src/auth/strategy/local.strategy.ts
+++ b/admin-api-server/src/auth/strategy/local.strategy.ts
@@ -1,8 +1,8 @@
 import { Strategy } from 'passport-local';
 import { PassportStrategy } from '@nestjs/passport';
 import { Injectable, UnauthorizedException } from '@nestjs/common';
-import { AuthService } from '../service/auth.service';
-import { UserEntity } from 'src/user/entities/user.entity';
+import { AuthService } from '../service/auth.service.js';
+import { UserEntity } from '../../user/entities/user.entity.js';
 
 @Injectable()
 export class LocalStrategy extends PassportStrategy(Strategy) {

--- a/admin-api-server/src/category/category.module.ts
+++ b/admin-api-server/src/category/category.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
-import { CategoryController } from './controller/category.controller';
-import { CategoryService } from './service/category.service';
-import { DbModule } from 'src/db.module';
+import { CategoryController } from './controller/category.controller.js';
+import { CategoryService } from './service/category.service.js';
+import { DbModule } from '../db.module.js';
 
 @Module({
   imports: [DbModule],

--- a/admin-api-server/src/category/controller/category.controller.spec.ts
+++ b/admin-api-server/src/category/controller/category.controller.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { CategoryController } from './category.controller';
 import { CategoryService } from '../service/category.service';
-import { DbMockModule } from 'src/db_mock.module';
+import { DbMockModule } from '../../db_mock.module';
 
 describe('CategoryController', () => {
   let controller: CategoryController;

--- a/admin-api-server/src/category/controller/category.controller.ts
+++ b/admin-api-server/src/category/controller/category.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, UseGuards } from '@nestjs/common';
-import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
-import { CategoryEntity } from '../../category/entity/category.entity';
-import { CategoryService } from '../service/category.service';
+import { JwtAuthGuard } from '../../auth/guard/jwt-auth.guard.js';
+import { CategoryEntity } from '../../category/entity/category.entity.js';
+import { CategoryService } from '../service/category.service.js';
 
 @Controller('categories')
 export class CategoryController {

--- a/admin-api-server/src/category/entity/category.entity.spec.ts
+++ b/admin-api-server/src/category/entity/category.entity.spec.ts
@@ -1,7 +1,0 @@
-// import { NftCategory } from './category.entity'
-
-describe('NftCategory', () => {
-  it('should satisfy the test runner', () => {
-    expect(true).toBeTruthy();
-  });
-});

--- a/admin-api-server/src/category/service/category.service.spec.ts
+++ b/admin-api-server/src/category/service/category.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { CategoryService } from './category.service';
-import { DbMockModule } from 'src/db_mock.module';
+import { CategoryService } from './category.service.js';
+import { DbMockModule } from '../../db_mock.module';
 
 describe('CategoryService', () => {
   let service: CategoryService;

--- a/admin-api-server/src/category/service/category.service.ts
+++ b/admin-api-server/src/category/service/category.service.ts
@@ -5,8 +5,8 @@ import {
   Injectable,
   Inject,
 } from '@nestjs/common';
-import { CategoryEntity } from '../entity/category.entity';
-import { PG_CONNECTION_STORE_REPLICATION } from '../../constants';
+import { CategoryEntity } from '../entity/category.entity.js';
+import { PG_CONNECTION_STORE_REPLICATION } from '../../constants.js';
 
 @Injectable()
 export class CategoryService {

--- a/admin-api-server/src/constants.ts
+++ b/admin-api-server/src/constants.ts
@@ -1,4 +1,4 @@
-import { assertEnv } from './utils';
+import { assertEnv } from './utils.js';
 import { maybe } from 'kanvas-api-lib';
 
 export const PG_CONNECTION = 'PG_CONNECTION';
@@ -9,8 +9,10 @@ export const PG_CONNECTION_STORE = 'PG_CONNECTION_STORE';
 export const PG_UNIQUE_VIOLATION_ERRCODE = '23505';
 export const AUTH_SALT_ROUNDS = 10;
 
+export const FILE_MAX_BYTES: number = 1000 * 1000 * 20;
 export const FILE_PREFIX = 'NFT_FILE_';
 export const MAX_FILE_UPLOADS_PER_CALL = 5;
+export const ALLOWED_FILE_MIMETYPES = ['image/png', 'image/jpeg'];
 
 export const RATE_LIMIT_WINDOW_SECS = Number(
   process.env['RATE_LIMIT_WINDOW_SECS'] || 60,

--- a/admin-api-server/src/db.module.ts
+++ b/admin-api-server/src/db.module.ts
@@ -1,8 +1,9 @@
 import { Module, Logger, Inject } from '@nestjs/common';
-import { assertEnv } from './utils';
-import { PG_CONNECTION, PG_CONNECTION_STORE_REPLICATION } from './constants';
 import { Client, types } from 'pg';
-import * as Pool from 'pg-pool';
+import Pool from 'pg-pool';
+
+import { assertEnv } from './utils.js';
+import { PG_CONNECTION, PG_CONNECTION_STORE_REPLICATION } from './constants.js';
 
 export type DbPool = Pool<Client>;
 
@@ -68,19 +69,24 @@ export class DbModule {
   constructor(@Inject('PG_POOL_WRAP') private w: Wrap) {}
 
   async onModuleDestroy() {
-    if (typeof this.w.dbPool === 'undefined') {
-      Logger.warn(
-        `pool already uninitialized! stacktrace: ${new Error().stack}`,
-      );
-      return;
-    }
     Logger.log('closing db connection..');
 
-    await this.w.dbPool.end();
-    this.w.dbPool = undefined;
-    await this.w.storeDbPool.end();
-    this.w.storeDbPool = undefined;
-
+    if (typeof this.w.dbPool === 'undefined') {
+      Logger.warn(
+        `dbPool already uninitialized! stacktrace: ${new Error().stack}`,
+      );
+    } else {
+      await this.w.dbPool.end();
+      this.w.dbPool = undefined;
+    }
+    if (typeof this.w.storeDbPool === 'undefined') {
+      Logger.warn(
+        `storeDbPool already uninitialized! stacktrace: ${new Error().stack}`,
+      );
+    } else {
+      await this.w.storeDbPool.end();
+      this.w.storeDbPool = undefined;
+    }
     Logger.log('db connection closed');
   }
 }

--- a/admin-api-server/src/db.module.ts
+++ b/admin-api-server/src/db.module.ts
@@ -1,5 +1,7 @@
 import { Module, Logger, Inject } from '@nestjs/common';
-import { Client, types } from 'pg';
+import { Client } from 'pg';
+import pg from 'pg';
+const { types } = pg;
 import Pool from 'pg-pool';
 
 import { assertEnv } from './utils.js';

--- a/admin-api-server/src/db_mock.module.ts
+++ b/admin-api-server/src/db_mock.module.ts
@@ -3,7 +3,7 @@ import {
   PG_CONNECTION,
   PG_CONNECTION_STORE_REPLICATION,
   PG_CONNECTION_STORE,
-} from './constants';
+} from './constants.js';
 
 class dbConnMock {}
 

--- a/admin-api-server/src/main.ts
+++ b/admin-api-server/src/main.ts
@@ -3,11 +3,11 @@ dotenv.config();
 
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
-import { AppModule } from './app.module';
-import { BEHIND_PROXY } from './constants';
+import { AppModule } from './app.module.js';
+import { BEHIND_PROXY } from './constants.js';
 import { NestExpressApplication } from '@nestjs/platform-express';
 
-var bodyParser = require('body-parser');
+import bodyParser from 'body-parser';
 
 async function bootstrap() {
   let cors: any = false;
@@ -17,7 +17,6 @@ async function bootstrap() {
       origin: true,
     };
   }
-  console.log(`cors: ${JSON.stringify(cors)}`);
 
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
     cors: cors,

--- a/admin-api-server/src/middleware/cookie_session.ts
+++ b/admin-api-server/src/middleware/cookie_session.ts
@@ -1,7 +1,9 @@
 import { Injectable, NestMiddleware } from '@nestjs/common';
-import cookieSession = require('cookie-session');
 import { v4 as uuidv4 } from 'uuid';
-import { assertEnv } from '../utils';
+import { assertEnv } from '../utils.js';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const cookieSession = require('cookie-session');
 
 @Injectable()
 export class CookieSessionMiddleware implements NestMiddleware {

--- a/admin-api-server/src/middleware/logger.ts
+++ b/admin-api-server/src/middleware/logger.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import { Injectable, NestMiddleware, Logger } from '@nestjs/common';
-import { BEHIND_PROXY } from '../constants';
+import { BEHIND_PROXY } from '../constants.js';
 
 @Injectable()
 export class LoggerMiddleware implements NestMiddleware {

--- a/admin-api-server/src/nft/controller/nft.controller.spec.ts
+++ b/admin-api-server/src/nft/controller/nft.controller.spec.ts
@@ -2,9 +2,9 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { NftController } from './nft.controller';
 import { NftService } from '../service/nft.service';
 import { S3Service } from '../service/s3.service';
-import { DbMockModule } from 'src/db_mock.module';
-import { RoleService } from 'src/role/service/role.service';
-import { CategoryService } from 'src/category/service/category.service';
+import { DbMockModule } from '../../db_mock.module';
+import { RoleService } from '../../role/service/role.service';
+import { CategoryService } from '../../category/service/category.service';
 
 describe('NftController', () => {
   let controller: NftController;

--- a/admin-api-server/src/nft/controller/nft.controller.ts
+++ b/admin-api-server/src/nft/controller/nft.controller.ts
@@ -13,22 +13,24 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import { FilesInterceptor } from '@nestjs/platform-express';
-import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
-import { MAX_FILE_UPLOADS_PER_CALL } from 'src/constants';
-import { NftEntity, NftUpdate } from '../entities/nft.entity';
-import { NftService } from '../service/nft.service';
-import { CurrentUser } from 'src/decoraters/user.decorator';
-import { UserEntity } from 'src/user/entities/user.entity';
-import { NftFilterParams, NftFilters } from '../params';
-import { ParseJSONArrayPipe } from 'src/pipes/ParseJSONArrayPipe';
+import { JwtAuthGuard } from '../../auth/guard/jwt-auth.guard.js';
+import { MAX_FILE_UPLOADS_PER_CALL } from '../../constants.js';
+import { NftEntity, NftUpdate } from '../entities/nft.entity.js';
+import { NftService } from '../service/nft.service.js';
+import { CurrentUser } from '../../decoraters/user.decorator.js';
+import { UserEntity } from '../../user/entities/user.entity.js';
+import { NftFilterParams, NftFilters } from '../params.js';
+import { ParseJSONArrayPipe } from '../../pipes/ParseJSONArrayPipe.js';
 import {
   queryParamsToPaginationParams,
   validatePaginationParams,
-} from 'src/utils';
+} from '../../utils.js';
 import { ContentRestrictions } from 'kanvas-stm-lib';
 const filesizeHuman = require('filesize').partial({ standard: 'jedec' });
 
-let getContentRestrictions: (string) => ContentRestrictions;
+let getContentRestrictions: (
+  attrName: string,
+) => ContentRestrictions | undefined;
 function contentFilter(req: any, file: any, callback: any) {
   if (typeof getContentRestrictions === 'undefined') {
     return callback(null, true);
@@ -57,7 +59,9 @@ function contentFilter(req: any, file: any, callback: any) {
 @Controller('nft')
 export class NftController {
   constructor(private readonly nftService: NftService) {
-    getContentRestrictions = (attrName: string) => {
+    getContentRestrictions = (
+      attrName: string,
+    ): ContentRestrictions | undefined => {
       return this.nftService.getContentRestrictions(attrName);
     };
   }
@@ -163,7 +167,7 @@ export class NftController {
     filters?: NftFilters,
     sort?: string[],
     range?: number[],
-  ) {
+  ): NftFilterParams {
     return {
       ...new NftFilterParams(),
       ...queryParamsToPaginationParams(sort, range),

--- a/admin-api-server/src/nft/controller/nft.controller.ts
+++ b/admin-api-server/src/nft/controller/nft.controller.ts
@@ -26,6 +26,9 @@ import {
   validatePaginationParams,
 } from '../../utils.js';
 import { ContentRestrictions } from 'kanvas-stm-lib';
+
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
 const filesizeHuman = require('filesize').partial({ standard: 'jedec' });
 
 let getContentRestrictions: (

--- a/admin-api-server/src/nft/nft.module.ts
+++ b/admin-api-server/src/nft/nft.module.ts
@@ -1,10 +1,10 @@
 import { Module } from '@nestjs/common';
-import { NftService } from './service/nft.service';
-import { NftController } from './controller/nft.controller';
-import { DbModule } from 'src/db.module';
-import { S3Service } from './service/s3.service';
-import { CategoryModule } from 'src/category/category.module';
-import { RoleModule } from 'src/role/role.module';
+import { NftService } from './service/nft.service.js';
+import { NftController } from './controller/nft.controller.js';
+import { DbModule } from '../db.module.js';
+import { S3Service } from './service/s3.service.js';
+import { CategoryModule } from '../category/category.module.js';
+import { RoleModule } from '../role/role.module.js';
 
 @Module({
   imports: [DbModule, CategoryModule, RoleModule],

--- a/admin-api-server/src/nft/params.ts
+++ b/admin-api-server/src/nft/params.ts
@@ -4,7 +4,7 @@ import {
   parseStringArray,
   parseNumberParam,
   PaginationParams,
-} from 'src/utils';
+} from '../utils.js';
 
 export class NftFilters {
   @IsArray()
@@ -21,5 +21,5 @@ export class NftFilters {
 }
 
 export class NftFilterParams extends PaginationParams {
-  filters: NftFilters = <NftFilters>{};
+  filters?: NftFilters = <NftFilters>{};
 }

--- a/admin-api-server/src/nft/service/nft.service.spec.ts
+++ b/admin-api-server/src/nft/service/nft.service.spec.ts
@@ -1,10 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { NftService } from './nft.service';
 import { S3Service } from './s3.service';
-import { DbMockModule } from 'src/db_mock.module';
-import { RoleService } from 'src/role/service/role.service';
-import { CategoryService } from 'src/category/service/category.service';
-import { sleep } from 'src/utils';
+import { DbMockModule } from '../../db_mock.module';
+import { RoleService } from '../../role/service/role.service';
+import { CategoryService } from '../../category/service/category.service';
+import { sleep } from '../../utils';
 
 describe('NftService', () => {
   let service: NftService;

--- a/admin-api-server/src/nft/service/nft.service.ts
+++ b/admin-api-server/src/nft/service/nft.service.ts
@@ -13,30 +13,33 @@ import {
   NFT_DELIST_STATE,
   STORE_API,
   ADMIN_PRIVATE_KEY,
-} from 'src/constants';
+} from '../../constants.js';
 import {
   SIGNATURE_PREFIX_CREATE_NFT,
   SIGNATURE_PREFIX_DELIST_NFT,
   SIGNATURE_PREFIX_RELIST_NFT,
 } from 'kanvas-api-lib';
-import { DbPool } from 'src/db.module';
+import { DbPool } from '../../db.module.js';
 import {
   STMResultStatus,
   StateTransitionMachine,
   Actor,
   ContentRestrictions,
 } from 'kanvas-stm-lib';
-import { UserEntity } from 'src/user/entities/user.entity';
-import { NftEntity, NftUpdate } from '../entities/nft.entity';
-import { NftFilterParams } from '../params';
-import { RoleService } from 'src/role/service/role.service';
-import { S3Service } from './s3.service';
-import { CategoryService } from 'src/category/service/category.service';
-import { CategoryEntity } from 'src/category/entity/category.entity';
+import { UserEntity } from '../../user/entities/user.entity.js';
+import { NftEntity, NftUpdate } from '../entities/nft.entity.js';
+import { NftFilterParams, NftFilters } from '../params.js';
+import { RoleService } from '../../role/service/role.service.js';
+import { S3Service } from './s3.service.js';
+import { CategoryService } from '../../category/service/category.service.js';
+import { CategoryEntity } from '../../category/entity/category.entity.js';
 import { Lock } from 'async-await-mutex-lock';
 import { cryptoUtils } from 'sotez';
 import axios from 'axios';
 import { watch, FSWatcher } from 'fs';
+
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
 const mime = require('mime');
 
 @Injectable()
@@ -144,7 +147,7 @@ ORDER BY ${orderBy} ${params.orderDirection} ${orderBy !== 'id' ? ', id' : ''}
 OFFSET ${params.pageOffset}
 LIMIT  ${params.pageSize}
       `,
-      [params.filters.nftStates, params.filters.nftIds],
+      [params.filters?.nftStates, params.filters?.nftIds],
     );
 
     if (qryRes.rowCount === 0) {
@@ -172,6 +175,7 @@ LIMIT  ${params.pageSize}
 
   async #findByIds(nftIds: number[]): Promise<NftEntity[]> {
     const filterParams = new NftFilterParams();
+    filterParams.filters = new NftFilters();
 
     filterParams.filters.nftIds = nftIds;
     filterParams.pageSize = nftIds.length;

--- a/admin-api-server/src/nft/service/nft.service.ts
+++ b/admin-api-server/src/nft/service/nft.service.ts
@@ -34,7 +34,8 @@ import { S3Service } from './s3.service.js';
 import { CategoryService } from '../../category/service/category.service.js';
 import { CategoryEntity } from '../../category/entity/category.entity.js';
 import { Lock } from 'async-await-mutex-lock';
-import { cryptoUtils } from 'sotez';
+import sotez from 'sotez';
+const { cryptoUtils } = sotez;
 import axios from 'axios';
 import { watch, FSWatcher } from 'fs';
 

--- a/admin-api-server/src/nft/service/s3.service.ts
+++ b/admin-api-server/src/nft/service/s3.service.ts
@@ -1,5 +1,6 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
-import { S3 } from 'aws-sdk';
+import aws from 'aws-sdk';
+const { S3 } = aws;
 
 const AWS_S3_BUCKET = process.env.AWS_S3_BUCKET;
 

--- a/admin-api-server/src/role/controller/role.controller.ts
+++ b/admin-api-server/src/role/controller/role.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, UseGuards } from '@nestjs/common';
-import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
-import { Roles } from '../entities/role.entity';
-import { RoleService } from '../service/role.service';
+import { JwtAuthGuard } from '../../auth/guard/jwt-auth.guard.js';
+import { Roles } from '../entities/role.entity.js';
+import { RoleService } from '../service/role.service.js';
 
 @Controller('role')
 export class RoleController {

--- a/admin-api-server/src/role/role.guard.ts
+++ b/admin-api-server/src/role/role.guard.ts
@@ -1,6 +1,6 @@
 import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { ROLES_KEY } from './role.decorator';
+import { ROLES_KEY } from './role.decorator.js';
 
 @Injectable()
 export class RolesGuard implements CanActivate {

--- a/admin-api-server/src/role/role.module.ts
+++ b/admin-api-server/src/role/role.module.ts
@@ -1,7 +1,7 @@
 import { Module } from '@nestjs/common';
-import { RoleService } from './service/role.service';
-import { RoleController } from './controller/role.controller';
-import { DbModule } from 'src/db.module';
+import { RoleService } from './service/role.service.js';
+import { RoleController } from './controller/role.controller.js';
+import { DbModule } from '../db.module.js';
 
 @Module({
   imports: [DbModule],

--- a/admin-api-server/src/role/service/role.service.ts
+++ b/admin-api-server/src/role/service/role.service.ts
@@ -1,14 +1,15 @@
 import { Injectable, Inject } from '@nestjs/common';
-import { PG_CONNECTION } from 'src/constants';
-import { DbPool } from 'src/db.module';
-import { Roles } from '../entities/role.entity';
+import { PG_CONNECTION } from '../../constants.js';
+import { DbPool } from '../../db.module.js';
+import { Roles } from '../entities/role.entity.js';
 
 @Injectable()
 export class RoleService {
   constructor(@Inject(PG_CONNECTION) private db: DbPool) {}
   async createRoles() {
-    for (const roleId of Object.keys(Roles)) {
-      if (isNaN(Number(roleId))) {
+    for (const roleIdStr of Object.keys(Roles)) {
+      const roleId: number = Number(roleIdStr);
+      if (isNaN(roleId)) {
         continue;
       }
       await this.db.query(

--- a/admin-api-server/src/seeds/index.ts
+++ b/admin-api-server/src/seeds/index.ts
@@ -1,4 +1,4 @@
-import { seedUser } from './user.seed';
+import { seedUser } from './user.seed.js';
 
 const runSeeds = async () => {
   await seedUser();

--- a/admin-api-server/src/seeds/user.seed.ts
+++ b/admin-api-server/src/seeds/user.seed.ts
@@ -1,8 +1,8 @@
-import { UserService } from 'src/user/service/user.service';
-import { RoleService } from 'src/role/service/role.service';
-import { Roles } from 'src/role/entities/role.entity';
-import { assertEnv } from 'src/utils';
-import * as Pool from 'pg-pool';
+import Pool from 'pg-pool';
+import { UserService } from '../user/service/user.service.js';
+import { RoleService } from '../role/service/role.service.js';
+import { Roles } from '../role/entities/role.entity.js';
+import { assertEnv } from '../utils.js';
 
 export const seedUser = async () => {
   const dbPool = new Pool({

--- a/admin-api-server/src/user/controller/user.controller.spec.ts
+++ b/admin-api-server/src/user/controller/user.controller.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UserController } from './user.controller';
 import { UserService } from '../service/user.service';
-import { DbMockModule } from 'src/db_mock.module';
+import { DbMockModule } from '../../db_mock.module';
 
 describe('UserController', () => {
   let controller: UserController;

--- a/admin-api-server/src/user/controller/user.controller.ts
+++ b/admin-api-server/src/user/controller/user.controller.ts
@@ -12,18 +12,18 @@ import {
   HttpException,
   Logger,
 } from '@nestjs/common';
-import { UserService } from '../service/user.service';
-import { RolesDecorator } from 'src/role/role.decorator';
-import { Roles } from 'src/role/entities/role.entity';
-import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
-import { RolesGuard } from 'src/role/role.guard';
-import { ParseJSONArrayPipe } from 'src/pipes/ParseJSONArrayPipe';
-import { UserFilterParams, UserFilters } from '../params';
-import { UserEntity } from '../entities/user.entity';
+import { UserService } from '../service/user.service.js';
+import { RolesDecorator } from '../../role/role.decorator.js';
+import { Roles } from '../../role/entities/role.entity.js';
+import { JwtAuthGuard } from '../../auth/guard/jwt-auth.guard.js';
+import { RolesGuard } from '../../role/role.guard.js';
+import { ParseJSONArrayPipe } from '../../pipes/ParseJSONArrayPipe.js';
+import { UserFilterParams, UserFilters } from '../params.js';
+import { UserEntity } from '../entities/user.entity.js';
 import {
   queryParamsToPaginationParams,
   validatePaginationParams,
-} from 'src/utils';
+} from '../../utils.js';
 
 @Controller('user')
 export class UserController {

--- a/admin-api-server/src/user/params.ts
+++ b/admin-api-server/src/user/params.ts
@@ -4,7 +4,7 @@ import {
   parseStringArray,
   parseNumberParam,
   PaginationParams,
-} from 'src/utils';
+} from '../utils.js';
 
 export class UserFilters {
   @IsArray()

--- a/admin-api-server/src/user/service/user.service.spec.ts
+++ b/admin-api-server/src/user/service/user.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UserService } from './user.service';
-import { DbMockModule } from 'src/db_mock.module';
+import { DbMockModule } from '../../db_mock.module';
 
 describe('UserService', () => {
   let service: UserService;

--- a/admin-api-server/src/user/service/user.service.ts
+++ b/admin-api-server/src/user/service/user.service.ts
@@ -6,18 +6,26 @@ import {
   Logger,
 } from '@nestjs/common';
 
-import { PG_CONNECTION } from '../../constants';
-import { DbPool } from '../../db.module';
-import { hashPassword } from '../../utils';
-import { UserEntity } from '../entities/user.entity';
-import { UserFilterParams } from '../params';
-import { Roles } from 'src/role/entities/role.entity';
+import { PG_CONNECTION } from '../../constants.js';
+import { DbPool } from '../../db.module.js';
+import { hashPassword } from '../../utils.js';
+import { UserEntity } from '../entities/user.entity.js';
+import { UserFilterParams } from '../params.js';
+import { Roles } from '../../role/entities/role.entity.js';
 
 @Injectable()
 export class UserService {
   constructor(@Inject(PG_CONNECTION) private db: DbPool) {}
 
-  async create({ password, roles, ...rest }: UserEntity): Promise<UserEntity> {
+  async create({
+    password,
+    roles,
+    id, // taking id here because we don't want it inside rest, it should be undefined
+    ...rest
+  }: UserEntity): Promise<UserEntity> {
+    if (typeof password === 'undefined') {
+      throw new HttpException(`no password defined`, HttpStatus.BAD_REQUEST);
+    }
     if (!this.#allRolesValid(roles)) {
       throw new HttpException(
         `(partially) invalid roles`,
@@ -165,7 +173,7 @@ GROUP BY ku.id
     return result.rows[0];
   }
 
-  async update(id: number, { roles, ...rest }) {
+  async update(id: number, { roles, ...rest }: UserEntity) {
     if (!this.#allRolesValid(roles)) {
       throw new HttpException(
         `(partially) invalid roles`,

--- a/admin-api-server/src/user/user.module.ts
+++ b/admin-api-server/src/user/user.module.ts
@@ -1,8 +1,8 @@
 import { Module } from '@nestjs/common';
 import { JoiPipeModule } from 'nestjs-joi';
-import { UserService } from './service/user.service';
-import { UserController } from './controller/user.controller';
-import { DbModule } from 'src/db.module';
+import { UserService } from './service/user.service.js';
+import { UserController } from './controller/user.controller.js';
+import { DbModule } from '../db.module.js';
 
 @Module({
   imports: [DbModule, JoiPipeModule],

--- a/admin-api-server/src/utils.ts
+++ b/admin-api-server/src/utils.ts
@@ -1,6 +1,6 @@
 import * as bcrypt from 'bcrypt';
-import { AUTH_SALT_ROUNDS } from './constants';
 import { HttpException, HttpStatus } from '@nestjs/common';
+import { AUTH_SALT_ROUNDS } from './constants.js';
 
 class AssertionError extends Error {
   constructor(message: string) {

--- a/admin-api-server/stm-lib/package.json
+++ b/admin-api-server/stm-lib/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "private": true,
   "main": "dist/main.js",
+  "type": "module",
   "scripts": {
     "build": "rimraf dist && tsc",
     "start": "NODE_ENV=production node ."

--- a/admin-api-server/stm-lib/src/expr.ts
+++ b/admin-api-server/stm-lib/src/expr.ts
@@ -1,6 +1,6 @@
-import * as log from 'log';
-import { Nft } from './types';
-import * as ext from './extensions';
+import log from 'log';
+import { Nft } from './types.js';
+import * as ext from './extensions.js';
 
 export function evalExpr<T>(nftState: Nft, s: string, defaultOnErr: T): T {
   log.debug(`evaluation '${s}'`);

--- a/admin-api-server/stm-lib/src/main.ts
+++ b/admin-api-server/stm-lib/src/main.ts
@@ -1,11 +1,13 @@
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
 require('log-node')();
 import {
   STMResultStatus,
   StateTransitionMachine,
   ContentRestrictions,
-} from './stm';
-import { Actor } from './types';
-import * as log from 'log';
+} from './stm.js';
+import { Actor } from './types.js';
+import log from 'log';
 
 export { STMResultStatus, StateTransitionMachine, Actor, ContentRestrictions };
 

--- a/admin-api-server/stm-lib/src/stm.ts
+++ b/admin-api-server/stm-lib/src/stm.ts
@@ -1,9 +1,13 @@
-import * as fs from 'fs';
-import { parse } from 'yaml';
-import { evalExpr, execExpr } from './expr';
-import { Nft, Actor } from './types';
-import * as log from 'log';
-import { isBottom, maybe } from './utils';
+import fs from 'fs';
+import yaml from 'yaml';
+const { parse } = yaml;
+import { evalExpr, execExpr } from './expr.js';
+import { Nft, Actor } from './types.js';
+import log from 'log';
+import { isBottom, maybe } from './utils.js';
+
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
 const filesizeParser = require('filesize-parser');
 
 interface State {
@@ -47,7 +51,7 @@ export class StateTransitionMachine {
     const file = fs.readFileSync(filepath, 'utf8');
     const parsed = parse(file);
 
-    console.log('parsing file..');
+    log.info('parsing file..');
     for (const attrName in parsed.attributes) {
       const attr = parsed.attributes[attrName];
 
@@ -78,7 +82,7 @@ export class StateTransitionMachine {
         mutables: st.mutables,
       };
     }
-    console.log(
+    log.info(
       `file parsed: ${JSON.stringify(this.attrTypes)}, ${JSON.stringify(
         this.contentRestrictions,
       )}`,

--- a/admin-api-server/stm-lib/tsconfig.json
+++ b/admin-api-server/stm-lib/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "es2022",
+    "moduleResolution": "node",
     "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,

--- a/admin-api-server/test/app.e2e.spec.ts
+++ b/admin-api-server/test/app.e2e.spec.ts
@@ -1,10 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, ValidationPipe } from '@nestjs/common';
-import * as request from 'supertest';
-import { AppModule } from 'src/app.module';
-import { Roles } from 'src/role/entities/role.entity';
-import { assertEnv } from 'src/utils';
-import * as Pool from 'pg-pool';
+import request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { Roles } from '../src/role/entities/role.entity';
+import { assertEnv } from '../src/utils';
+import Pool from 'pg-pool';
 import axios from 'axios';
 
 let anyTestFailed = false;

--- a/admin-api-server/test/coverage/summary.txt
+++ b/admin-api-server/test/coverage/summary.txt
@@ -1,142 +1,160 @@
 
---------------------------|---------|----------|---------|---------|--------------------------------------------------------
+--------------------------|---------|----------|---------|---------|-----------------------------------------------------------------------------
 
-File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                      
+File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                                           
 
---------------------------|---------|----------|---------|---------|--------------------------------------------------------
+--------------------------|---------|----------|---------|---------|-----------------------------------------------------------------------------
 
-All files                 |   86.84 |    65.38 |    89.1 |   85.62 |                                                        
+All files                 |   86.09 |    83.83 |   85.83 |   86.09 |                                                                             
 
- src                      |   79.86 |    67.56 |   85.71 |   78.72 |                                                        
+ src                      |   82.68 |    76.92 |   82.35 |   82.68 |                                                                             
 
-  app.module.ts           |     100 |      100 |     100 |     100 |                                                        
+  app.module.ts           |     100 |      100 |     100 |     100 |                                                                             
 
-  constants.ts            |     100 |       80 |     100 |     100 | 21-25                                                  
+  constants.ts            |     100 |        0 |     100 |     100 | 23-27                                                                       
 
-  db.module.ts            |   87.09 |        0 |     100 |    86.2 | 32,50,72-75                                            
+  db.module.ts            |   89.36 |    55.55 |     100 |   89.36 | 35-36,53-54,77-79,85-87                                                     
 
-  db_mock.module.ts       |     100 |      100 |     100 |     100 |                                                        
+  db_mock.module.ts       |     100 |      100 |     100 |     100 |                                                                             
 
-  main.ts                 |       0 |        0 |       0 |       0 | 1-41                                                   
+  main.ts                 |       0 |        0 |       0 |       0 | 1-40                                                                        
 
-  utils.ts                |   90.74 |       85 |   85.71 |   90.38 | 7,12-13,29,112                                         
+  utils.ts                |   90.08 |     92.3 |   81.81 |   90.08 | 7-8,12-15,29-32,112-113                                                     
 
- src/analytics            |      85 |      100 |      25 |   83.33 |                                                        
+ src/analytics            |     100 |      100 |     100 |     100 |                                                                             
 
-  analytics.module.ts     |     100 |      100 |     100 |     100 |                                                        
+  analytics.module.ts     |     100 |      100 |     100 |     100 |                                                                             
 
-  params.ts               |      75 |      100 |      25 |      75 | 11,16,21                                               
+  params.ts               |     100 |      100 |     100 |     100 |                                                                             
 
- src/analytics/controller |     100 |    83.33 |     100 |     100 |                                                        
+ src/analytics/controller |     100 |    94.44 |     100 |     100 |                                                                             
 
-  analytics.controller.ts |     100 |    83.33 |     100 |     100 | 124                                                    
+  analytics.controller.ts |     100 |    94.44 |     100 |     100 | 124                                                                         
 
- src/analytics/entity     |     100 |      100 |     100 |     100 |                                                        
+ src/analytics/entity     |     100 |      100 |     100 |     100 |                                                                             
 
-  analytics.entity.ts     |     100 |      100 |     100 |     100 |                                                        
+  analytics.entity.ts     |     100 |      100 |     100 |     100 |                                                                             
 
- src/analytics/service    |     100 |      100 |     100 |     100 |                                                        
+ src/analytics/service    |     100 |      100 |     100 |     100 |                                                                             
 
-  analytics.service.ts    |     100 |      100 |     100 |     100 |                                                        
+  analytics.service.ts    |     100 |      100 |     100 |     100 |                                                                             
 
- src/auth                 |     100 |      100 |     100 |     100 |                                                        
+ src/auth                 |     100 |      100 |     100 |     100 |                                                                             
 
-  auth.module.ts          |     100 |      100 |     100 |     100 |                                                        
+  auth.module.ts          |     100 |      100 |     100 |     100 |                                                                             
 
- src/auth/controller      |     100 |      100 |     100 |     100 |                                                        
+ src/auth/controller      |     100 |      100 |     100 |     100 |                                                                             
 
-  auth.controller.ts      |     100 |      100 |     100 |     100 |                                                        
+  auth.controller.ts      |     100 |      100 |     100 |     100 |                                                                             
 
- src/auth/guard           |     100 |      100 |     100 |     100 |                                                        
+ src/auth/guard           |     100 |      100 |     100 |     100 |                                                                             
 
-  jwt-auth.guard.ts       |     100 |      100 |     100 |     100 |                                                        
+  jwt-auth.guard.ts       |     100 |      100 |     100 |     100 |                                                                             
 
- src/auth/service         |     100 |      100 |     100 |     100 |                                                        
+ src/auth/service         |     100 |      100 |     100 |     100 |                                                                             
 
-  auth.service.ts         |     100 |      100 |     100 |     100 |                                                        
+  auth.service.ts         |     100 |      100 |     100 |     100 |                                                                             
 
- src/auth/strategy        |   96.15 |      100 |     100 |   95.45 |                                                        
+ src/auth/strategy        |   95.65 |    85.71 |     100 |   95.65 |                                                                             
 
-  jwt.strategy.ts         |    92.3 |      100 |     100 |    90.9 | 21                                                     
+  jwt.strategy.ts         |    91.3 |    66.66 |     100 |    91.3 | 21-22                                                                       
 
-  local.strategy.ts       |     100 |      100 |     100 |     100 |                                                        
+  local.strategy.ts       |     100 |      100 |     100 |     100 |                                                                             
 
- src/category             |     100 |      100 |     100 |     100 |                                                        
+ src/category             |     100 |      100 |     100 |     100 |                                                                             
 
-  category.module.ts      |     100 |      100 |     100 |     100 |                                                        
+  category.module.ts      |     100 |      100 |     100 |     100 |                                                                             
 
- src/category/controller  |     100 |      100 |     100 |     100 |                                                        
+ src/category/controller  |     100 |      100 |     100 |     100 |                                                                             
 
-  category.controller.ts  |     100 |      100 |     100 |     100 |                                                        
+  category.controller.ts  |     100 |      100 |     100 |     100 |                                                                             
 
- src/category/service     |   83.33 |      100 |     100 |      80 |                                                        
+ src/category/entity      |       0 |        0 |       0 |       0 |                                                                             
 
-  category.service.ts     |   83.33 |      100 |     100 |      80 | 35-36                                                  
+  category.entity.ts      |       0 |        0 |       0 |       0 | 1-4                                                                         
 
- src/decoraters           |     100 |       50 |     100 |     100 |                                                        
+ src/category/service     |   85.71 |       75 |     100 |   85.71 |                                                                             
 
-  proxied_throttler.ts    |     100 |       50 |     100 |     100 | 7                                                      
+  category.service.ts     |   85.71 |       75 |     100 |   85.71 | 35-40                                                                       
 
-  user.decorator.ts       |     100 |      100 |     100 |     100 |                                                        
+ src/decoraters           |     100 |    66.66 |     100 |     100 |                                                                             
 
- src/middleware           |     100 |    61.53 |     100 |     100 |                                                        
+  proxied_throttler.ts    |     100 |       50 |     100 |     100 | 7                                                                           
 
-  cookie_session.ts       |     100 |      100 |     100 |     100 |                                                        
+  user.decorator.ts       |     100 |      100 |     100 |     100 |                                                                             
 
-  logger.ts               |     100 |    58.33 |     100 |     100 | 12-13                                                  
+ src/middleware           |     100 |    66.66 |     100 |     100 |                                                                             
 
- src/nft                  |     100 |       75 |     100 |     100 |                                                        
+  cookie_session.ts       |     100 |      100 |     100 |     100 |                                                                             
 
-  nft.module.ts           |     100 |      100 |     100 |     100 |                                                        
+  logger.ts               |     100 |       50 |     100 |     100 | 12-13                                                                       
 
-  params.ts               |     100 |       75 |     100 |     100 | 17                                                     
+ src/nft                  |     100 |       80 |     100 |     100 |                                                                             
 
- src/nft/controller       |   66.66 |     7.14 |   72.72 |   65.45 |                                                        
+  nft.module.ts           |     100 |      100 |     100 |     100 |                                                                             
 
-  nft.controller.ts       |   66.66 |     7.14 |   72.72 |   65.45 | 33-54,61,136-152                                       
+  params.ts               |     100 |       80 |     100 |     100 | 17                                                                          
 
- src/nft/service          |   80.52 |    62.16 |   88.23 |      80 |                                                        
+ src/nft/controller       |   72.77 |     90.9 |      80 |   72.77 |                                                                             
 
-  nft.service.ts          |   82.95 |    63.88 |   90.62 |   82.65 | 61-64,71-80,97,218-219,244,271,331-332,346-368,453,539 
+  nft.controller.ts       |   72.77 |     90.9 |      80 |   72.77 | 37-60,66-68,143-164                                                         
 
-  s3.service.ts           |      50 |        0 |      50 |   41.66 | 14-37                                                  
+ src/nft/entities         |       0 |        0 |       0 |       0 |                                                                             
 
- src/pipes                |      70 |       80 |     100 |    62.5 |                                                        
+  nft.entity.ts           |       0 |        0 |       0 |       0 | 1-15                                                                        
 
-  ParseJSONArrayPipe.ts   |      70 |       80 |     100 |    62.5 | 13,17-18                                               
+ src/nft/service          |   82.28 |     86.3 |    87.5 |   82.28 |                                                                             
 
- src/role                 |      96 |       60 |     100 |   94.73 |                                                        
+  nft.service.ts          |   86.07 |    86.11 |    90.9 |   86.07 | 65-69,75-87,101-102,223-228,249-255,276-279,336-337,344-377,458-459,543-545 
 
-  role.decorator.ts       |     100 |      100 |     100 |     100 |                                                        
+  s3.service.ts           |   34.09 |      100 |      50 |   34.09 | 15-43                                                                       
 
-  role.guard.ts           |    92.3 |       60 |     100 |      90 | 15                                                     
+ src/pipes                |   76.19 |       60 |     100 |   76.19 |                                                                             
 
-  role.module.ts          |     100 |      100 |     100 |     100 |                                                        
+  ParseJSONArrayPipe.ts   |   76.19 |       60 |     100 |   76.19 | 13-14,17-19                                                                 
 
- src/role/controller      |   77.77 |      100 |       0 |   71.42 |                                                        
+ src/role                 |   94.73 |    66.66 |     100 |   94.73 |                                                                             
 
-  role.controller.ts      |   77.77 |      100 |       0 |   71.42 | 8,13                                                   
+  role.decorator.ts       |     100 |      100 |     100 |     100 |                                                                             
 
- src/role/entities        |     100 |      100 |     100 |     100 |                                                        
+  role.guard.ts           |   90.47 |       60 |     100 |   90.47 | 15-16                                                                       
 
-  role.entity.ts          |     100 |      100 |     100 |     100 |                                                        
+  role.module.ts          |     100 |      100 |     100 |     100 |                                                                             
 
- src/role/service         |    62.5 |        0 |      60 |   53.84 |                                                        
+ src/role/controller      |   86.66 |      100 |       0 |   86.66 |                                                                             
 
-  role.service.ts         |    62.5 |        0 |      60 |   53.84 | 10-14,40-46                                            
+  role.controller.ts      |   86.66 |      100 |       0 |   86.66 | 13-14                                                                       
 
- src/user                 |     100 |       75 |     100 |     100 |                                                        
+ src/role/entities        |     100 |      100 |     100 |     100 |                                                                             
 
-  params.ts               |     100 |       75 |     100 |     100 | 12-24                                                  
+  role.entity.ts          |     100 |      100 |     100 |     100 |                                                                             
 
-  user.module.ts          |     100 |      100 |     100 |     100 |                                                        
+ src/role/service         |   48.97 |      100 |      50 |   48.97 |                                                                             
 
- src/user/controller      |     100 |      100 |     100 |     100 |                                                        
+  role.service.ts         |   48.97 |      100 |      50 |   48.97 | 10-26,41-48                                                                 
 
-  user.controller.ts      |     100 |      100 |     100 |     100 |                                                        
+ src/seeds                |       0 |        0 |       0 |       0 |                                                                             
 
- src/user/service         |   89.55 |     87.5 |     100 |    88.7 |                                                        
+  index.ts                |       0 |        0 |       0 |       0 | 1-8                                                                         
 
-  user.service.ts         |   89.55 |     87.5 |     100 |    88.7 | 56-63,210-212,229                                      
+  user.seed.ts            |       0 |        0 |       0 |       0 | 1-29                                                                        
 
---------------------------|---------|----------|---------|---------|--------------------------------------------------------
+ src/user                 |     100 |       75 |     100 |     100 |                                                                             
+
+  params.ts               |     100 |       75 |     100 |     100 | 12,24                                                                       
+
+  user.module.ts          |     100 |      100 |     100 |     100 |                                                                             
+
+ src/user/controller      |     100 |      100 |     100 |     100 |                                                                             
+
+  user.controller.ts      |     100 |      100 |     100 |     100 |                                                                             
+
+ src/user/entities        |       0 |        0 |       0 |       0 |                                                                             
+
+  user.entity.ts          |       0 |        0 |       0 |       0 | 1-8                                                                         
+
+ src/user/service         |   91.09 |    86.66 |     100 |   91.09 |                                                                             
+
+  user.service.ts         |   91.09 |    86.66 |     100 |   91.09 | 27-28,64-75,218-220,237-241                                                 
+
+--------------------------|---------|----------|---------|---------|-----------------------------------------------------------------------------

--- a/admin-api-server/tsconfig.build.json
+++ b/admin-api-server/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["lib", "node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": ["stm-lib", "node_modules", "test", "dist", "**/*spec.ts"]
 }

--- a/admin-api-server/tsconfig.json
+++ b/admin-api-server/tsconfig.json
@@ -10,6 +10,7 @@
     "esModuleInterop": true,
     "target": "es2017",
     "sourceMap": true,
+    "rootDir": ".",
     "outDir": "./dist",
     "incremental": true,
     "strict": true,

--- a/admin-api-server/tsconfig.json
+++ b/admin-api-server/tsconfig.json
@@ -1,17 +1,23 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "es2022",
+    "moduleResolution": "node",
     "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "target": "es2017",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
     "incremental": true,
-    "noImplicitAny": false,
-    "allowJs": true
+    "strict": true,
+    "strictPropertyInitialization": false,
+    "types": [
+      "node", "jest"
+    ], "lib": [
+      "es2020"
+    ]
   }
 }

--- a/admin-api-server/yarn.lock
+++ b/admin-api-server/yarn.lock
@@ -1206,6 +1206,14 @@
   resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.2.tgz#66ad9331f63fe8a3d3d9d8c6e3906dd10f6446e8"
   integrity sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==
 
+"@types/cron@^1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@types/cron/-/cron-1.7.3.tgz#993db7d54646f61128c851607b64ba4495deae93"
+  integrity sha512-iPmUXyIJG1Js+ldPYhOQcYU3kCAQ2FWrSkm1FJPoii2eYSn6wEW6onPukNTT0bfiflexNSRPl6KWmAIqS+36YA==
+  dependencies:
+    "@types/node" "*"
+    moment ">=2.14.0"
+
 "@types/eslint-scope@^3.7.0":
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.3.tgz#125b88504b61e3c8bc6f870882003253005c3224"
@@ -1422,6 +1430,16 @@
   integrity sha512-uci4Esokrw9qGb9bvhhSVEjd6rkny/dk5PK/Qz4yxKiyppEI+dOPlNrZBahE3i+PoKFYyDxChVXZ/ysS/nrm1Q==
   dependencies:
     "@types/superagent" "*"
+
+"@types/uuid@^8.3.4":
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
+  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
+
+"@types/validator@^13.7.2":
+  version "13.7.2"
+  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.7.2.tgz#a2114225d9be743fb154b06c29b8257aaca42922"
+  integrity sha512-KFcchQ3h0OPQgFirBRPZr5F/sVjxZsOrQHedj3zi8AH3Zv/hOLx2OLR4hxR5HcfoU+33n69ZuOfzthKVdMoTiw==
 
 "@types/yargs-parser@*":
   version "20.2.1"
@@ -2124,11 +2142,6 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
-buffer-crc32@~0.2.3:
-  version "0.2.13"
-  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
-  integrity sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
-
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
@@ -2330,25 +2343,6 @@ class-validator@^0.13.1:
   dependencies:
     libphonenumber-js "^1.9.43"
     validator "^13.7.0"
-
-cldr-data-downloader@1.0.0-1:
-  version "1.0.0-1"
-  resolved "https://registry.yarnpkg.com/cldr-data-downloader/-/cldr-data-downloader-1.0.0-1.tgz#0ef01877bd20e4bbda661d84e67bdbd048aa8766"
-  integrity sha512-jskJncLkJlkBCdqdgzLSV9sOOLyEdeVOtwJOwVwRyliVJ+4822KZWvfaD620c9Lk7el3auwFDg92FXYjGA5BhQ==
-  dependencies:
-    axios "^0.26.0"
-    mkdirp "0.5.5"
-    nopt "3.0.x"
-    q "1.0.1"
-    yauzl "^2.10.0"
-
-cldr-data@^36.0.1:
-  version "36.0.1"
-  resolved "https://registry.yarnpkg.com/cldr-data/-/cldr-data-36.0.1.tgz#dc2dd39534399bda7892669444a87eb0b5ffc5e8"
-  integrity sha512-74leCbj4QIBno+a8MVwO4Kiqv4J1PXDcFhlgOhh86rnLljppLxxi8odVeMjqFsnEG2xxCu98P4iO9mkNXn5v9Q==
-  dependencies:
-    cldr-data-downloader "1.0.0-1"
-    glob "5.x.x"
 
 cli-cursor@^3.1.0:
   version "3.1.0"
@@ -3108,13 +3102,6 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fd-slicer@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
-  integrity sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==
-  dependencies:
-    pend "~1.2.0"
-
 figures@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
@@ -3354,17 +3341,6 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@5.x.x:
-  version "5.0.15"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
-  integrity sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==
-  dependencies:
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "2 || 3"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
 glob@^7.0.0, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
@@ -3519,11 +3495,6 @@ human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
-
-iana-tz-data@^2019.1.0:
-  version "2019.1.0"
-  resolved "https://registry.yarnpkg.com/iana-tz-data/-/iana-tz-data-2019.1.0.tgz#c02ad2ebec7dadccc6ad8bec0792610041606b93"
-  integrity sha512-T7+26Skkyxqjp4mg20/O065j9J5qP39nWVQj/2ArxQ0gSPkL+T9lwerRmiOAzFRNsNXepX45QqchqTVENwNvig==
 
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
@@ -4549,13 +4520,6 @@ minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-"minimatch@2 || 3":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
-  dependencies:
-    brace-expansion "^1.1.7"
-
 minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -4583,7 +4547,7 @@ minizlib@^2.1.1:
     minipass "^3.0.0"
     yallist "^4.0.0"
 
-mkdirp@0.5.5, mkdirp@^0.5.4:
+mkdirp@^0.5.4:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -4602,7 +4566,7 @@ moment-timezone@^0.5.x:
   dependencies:
     moment ">= 2.9.0"
 
-"moment@>= 2.9.0":
+"moment@>= 2.9.0", moment@>=2.14.0:
   version "2.29.3"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.3.tgz#edd47411c322413999f7a5940d526de183c031f3"
   integrity sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==
@@ -4706,13 +4670,6 @@ node-releases@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.5.tgz#280ed5bc3eba0d96ce44897d8aee478bfb3d9666"
   integrity sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==
-
-nopt@3.0.x:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
-  integrity sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==
-  dependencies:
-    abbrev "1"
 
 nopt@^5.0.0:
   version "5.0.0"
@@ -4954,11 +4911,6 @@ pbkdf2@^3.0.9, pbkdf2@^3.1.2:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-pend@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
-  integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
-
 pg-connection-string@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.5.0.tgz#538cadd0f7e603fc09a12590f3b8a452c2c0cf34"
@@ -5124,11 +5076,6 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
-
-q@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/q/-/q-1.0.1.tgz#11872aeedee89268110b10a718448ffb10112a14"
-  integrity sha512-18MnBaCeBX9sLRUdtxz/6onlb7wLzFxCylklyO8n27y5JxJYaGLPu4ccyc5zih58SpEzY8QmfwaWqguqXU6Y+A==
 
 qs@6.7.0:
   version "6.7.0"
@@ -6241,14 +6188,6 @@ yargs@^17.3.1:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
-
-yauzl@^2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
-  integrity sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==
-  dependencies:
-    buffer-crc32 "~0.2.3"
-    fd-slicer "~1.1.0"
 
 yn@3.1.1:
   version "3.1.1"

--- a/store-api-server/package.json
+++ b/store-api-server/package.json
@@ -14,7 +14,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/src/main",
+    "start:prod": "node dist/src/main.js",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "./script/test"
   },
@@ -118,6 +118,10 @@
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
+    "transformIgnorePatterns": [
+        "<rootDir>/node_modules/",
+        "/kanvas/lib/api-lib/"
+    ],
     "collectCoverageFrom": [
       "src/**/{!(nft_mock.service),}.ts"
     ],

--- a/store-api-server/tsconfig.json
+++ b/store-api-server/tsconfig.json
@@ -10,6 +10,7 @@
     "esModuleInterop": true,
     "target": "es2017",
     "sourceMap": true,
+    "rootDir": ".",
     "outDir": "./dist",
     "incremental": true,
     "strict": true,
@@ -18,6 +19,6 @@
       "node", "jest"
     ], "lib": [
       "es2020"
-    ],
+    ]
   }
 }


### PR DESCRIPTION
The admin-api was the only component that was still running in CommonJS mode, which is slowly being moved away from by libraries and the Javascript space in general to ESM. In ~April I already upgraded the store-api from CommonJS to ESM, but had to leave this step for the admin-api til later.

The move to ESM is important because ESM fixes some inherent vulnerabilities of CommonJS, and (because of that) any library that is ESM itself cannot be loaded from CommonJS, and since more and more libraries are moving to ESM sooner or later we'll have to be in ESM mode ourselves. It's also just important to have consistency between the 4 components, so this PR mostly is about addressing this tech debt.

Note:
- also fixed some issue where local builds would compile typescript code into `dist/` and dockerized builds would compile into `dist/src/`. This then resulted in `yarn run start:prod` not working when running non-dockerized because it assumed main.js to be in `dist/src/`. This was an issue with admin-api as well as with store-api, fixed for both. (the fix involved setting `"rootDir": "."` in package.json, if not set it's defaulted to something not entirely clear based on what, and somehow the default deviated in local builds vs dockerized builds)
- also fixed some noisy test output, where ts-jest would warn about omitting transpiling some js files that it shouldn't even bother about anyways (these are the `transformIgnorePatterns` additions), also fixed for both admin-api and store-api.

---

Note: moving to ESM does mean that import paths are a bit more convoluted now in admin-api, same as in store-api and in the frontend compontents. No longer is it possible to just import without extension if the file is a local project file, it's now necessary to import with `.js` extension then. Unless it's one of the .ts files that is loaded by the testing environment `jest` (these are the `.spec.ts` files).