### PR TITLE
Parallel test env setup

### DIFF
--- a/admin-api-server/package.json
+++ b/admin-api-server/package.json
@@ -10,6 +10,7 @@
     "prebuild": "rimraf dist",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
+    "postinstall": "./script/build-deps",
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",

--- a/admin-api-server/script/build-deps
+++ b/admin-api-server/script/build-deps
@@ -4,17 +4,28 @@ cd $SCRIPT_DIR/..
 
 set -u
 
+sig_err_file=`mktemp`
+rm $sig_err_file
 echo "building stm-lib.."
 (
+    trap "echo 'stm-lib build failed' >> $sig_err_file" ERR
+
     cd stm-lib
     yarn build
 ) &
 echo "building api-lib.."
 (
+    trap "echo 'api-lib build failed' >> $sig_err_file" ERR
+
     cd ../lib/api-lib
     yarn build
 ) &
 wait
+[ -f $sig_err_file ] && {
+    cat $sig_err_file
+    rm $sig_err_file
+    exit 1
+}
 
 links=`ls -l node_modules | grep ^l`
 echo "$links" | grep --silent 'kanvas-stm-lib ->' || {

--- a/admin-api-server/script/build-deps
+++ b/admin-api-server/script/build-deps
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd $SCRIPT_DIR/..
+
+set -u
+
+echo "building stm-lib.."
+(
+    cd stm-lib
+    yarn build
+) &
+echo "building api-lib.."
+(
+    cd ../lib/api-lib
+    yarn build
+) &
+wait
+
+links=`ls -l node_modules | grep ^l`
+echo "$links" | grep --silent 'kanvas-stm-lib ->' || {
+    echo "linking stm-lib.."
+    (
+        cd stm-lib
+        yarn link 2>/dev/null
+    )
+    yarn link kanvas-stm-lib
+}
+echo "$links" | grep --silent 'kanvas-api-lib ->' || {
+    echo "linking api-lib.."
+    (
+        cd ../lib/api-lib
+        yarn link 2>/dev/null
+    )
+    yarn link kanvas-api-lib
+}

--- a/admin-api-server/script/test
+++ b/admin-api-server/script/test
@@ -2,11 +2,6 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR/..
 
-(
-    cd stm-lib
-    yarn build
-)
-
 set -a
 . .env.test
 set +a
@@ -36,20 +31,47 @@ db_docker=`DOCKER_ARGS='-d' DBSETUP_LOG=quiet INIT_QUEPASA=false ./script/local-
 assert_docker_ok $PGPORT
 trap "docker kill $db_docker" EXIT
 
-echo "waiting for testdb setup (admin).. (docker: $db_docker)"
-./script/wait-db
-
-echo "waiting for testdb setup (store).."
-store_env_exec ../store-api-server/script/wait-db
-
-echo "setting up the store db"
+sig_err_file=`mktemp`
+rm $sig_err_file
 (
-    cd $SCRIPT_DIR/../../store-api-server;
-    yarn build || exit 1
+    trap "echo 'yarn linked deps build failed' >> $sig_err_file" ERR
 
-    store_env_exec script/migrate >/dev/null 2>&1 || exit 1
-    store_env_exec psql < script/populate-testdb.sql || exit 1
-) || exit 1
+    echo "ensuring up to date build w/ yarn linked deps (api-lib, etc)..."
+    ./script/build-deps || exit 1
+) &
+(
+    trap "echo 'store build failed' >> $sig_err_file" ERR
+
+    cd $SCRIPT_DIR/../../store-api-server;
+    ./script/build-deps >/dev/null 2>&1 || exit 1
+    yarn build || exit 1
+) &
+(
+    trap "echo 'db setup failed..' >> $sig_err_file" ERR
+
+    echo "waiting for testdb setup (admin).. (docker: $db_docker)"
+    ./script/wait-db
+
+    echo "setting up the store db"
+    (
+        cd "$SCRIPT_DIR/../../store-api-server"
+
+        set -a
+        . .env.test
+        set +a
+
+        echo "waiting for testdb setup (store).."
+        store_env_exec script/wait-db
+        store_env_exec script/migrate >/dev/null 2>&1 || exit 1
+        store_env_exec psql < script/populate-testdb.sql || exit 1
+    ) || exit 1
+) &
+wait
+[ -f $sig_err_file ] && {
+    cat $sig_err_file
+    rm $sig_err_file
+    exit 1
+}
 
 echo "starting the store api in the background"
 # enabling job control with set -m here, this will enforce a new process group
@@ -57,11 +79,7 @@ echo "starting the store api in the background"
 # proper kill of all child processes by kill on process group id.
 set -m
 (
-    cd $SCRIPT_DIR/../../store-api-server
-    yarn build || exit 1
-
-    set -a
-    . .env.test
+    cd "$SCRIPT_DIR/../../store-api-server"
 
     DOTENV_CONFIG_PATH=.env.test store_env_exec yarn run start:prod >/dev/null 2>&1
 ) &

--- a/store-api-server/package.json
+++ b/store-api-server/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "nest build",
-    "postinstall": "yarn run patch-package",
+    "postinstall": "yarn run patch-package; ./script/build-deps",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",

--- a/store-api-server/script/build-deps
+++ b/store-api-server/script/build-deps
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+cd $SCRIPT_DIR/..
+
+set -u
+
+echo "building api-lib.."
+(
+    cd ../lib/api-lib
+    yarn build
+)
+
+links=`ls -l node_modules | grep ^l`
+echo "$links" | grep --silent 'kanvas-api-lib ->' || {
+    echo "linking api-lib.."
+    (
+        cd ../lib/api-lib
+        yarn link 2>/dev/null
+    )
+    yarn link kanvas-api-lib
+}
+echo "$links" | grep --silent 'tezpay-server ->' || {
+    echo "linking tezpay-server.."
+    (
+        cd ../lib/tezpay/server
+        yarn link 2>/dev/null
+    )
+    yarn link tezpay-server
+}

--- a/store-api-server/script/test
+++ b/store-api-server/script/test
@@ -5,7 +5,6 @@ cd $SCRIPT_DIR/..
 set -a
 . .env.test
 set +a
-
 export $(grep --regexp='^ADMIN_PRIVATE_KEY' ../admin-api-server/.env.test | xargs)
 
 db_docker=`DBSETUP_LOG=quiet DOCKER_ARGS='-d' ./script/local-db 2>/dev/null`
@@ -17,12 +16,30 @@ if [[ "$?" != "0" ]]; then
 fi
 trap "docker kill $db_docker" EXIT
 
-echo "waiting for testdb setup.. (docker: $db_docker)"
-./script/wait-db
+sig_err_file=`mktemp`
+rm $sig_err_file
+(
+    trap "echo 'yarn linked deps build failed' >> $sig_err_file" ERR
 
-while [ "`HOST=$PGHOST PORT=$PGPORT LOGIN=$PGUSER PASSWORD=$PGPASSWORD ./script/shmig -t postgresql -d $PGDATABASE pending`" != "" ]; do
-    sleep 1
-done
+    echo "ensuring up to date build w/ yarn linked deps (api-lib, etc)..."
+    ./script/build-deps || exit 1
+) &
+(
+    trap "echo 'db setup failed' >> $sig_err_file" ERR
+
+    echo "waiting for testdb setup.. (docker: $db_docker)"
+    ./script/wait-db
+
+    while [ "`HOST=$PGHOST PORT=$PGPORT LOGIN=$PGUSER PASSWORD=$PGPASSWORD ./script/shmig -t postgresql -d $PGDATABASE pending`" != "" ]; do
+        sleep 1
+    done
+) &
+wait
+[ -f $sig_err_file ] && {
+    cat $sig_err_file
+    rm $sig_err_file
+    exit 1
+}
 
 echo "running tests.."
 

--- a/store-api-server/yarn.lock
+++ b/store-api-server/yarn.lock
@@ -1783,11 +1783,6 @@ b4a@^1.0.1:
   resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.3.1.tgz#5ead1402bd4a2dcfea35cc83928815d53315ff32"
   integrity sha512-ULHjbJGjZcdA5bugDNAAcMA6GWXX/9N10I6AQc14TH+Sr7bMfT+NHuJnOFGPJWLtzYa6Tz+PnFD2D/1bISLLZQ==
 
-babel-core@^7.0.0-bridge.0:
-  version "7.0.0-bridge.0"
-  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
-  integrity sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==
-
 babel-jest@^28.1.2:
   version "28.1.2"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-28.1.2.tgz#2b37fb81439f14d34d8b2cc4a4bd7efabf9acbfe"


### PR DESCRIPTION
Improve 'yarn test' times by doing things in parallel where possible during test environment setup (database setup, and making sure dependencies are up to date w/ the new build-deps scripts).

Biggest improvement for admin-api tests: these used to take ~70-80 secs, now they take ~50-60 secs. Most of the time is now spent by jest (running the tests themselves) rather than by the setup of env.