### PR TITLE
create simplex events to database for saving payment results for simplex

### DIFF
--- a/store-api-server/migrations/1661951074-insert-simplex-payment-event.sql
+++ b/store-api-server/migrations/1661951074-insert-simplex-payment-event.sql
@@ -1,0 +1,36 @@
+-- Migration: insert-simplex-payment-event
+-- Created at: 2022-08-31 16:04:34
+-- ====  UP  ====
+
+BEGIN;
+
+CREATE TABLE simplex_payment_event (
+    id SERIAL PRIMARY KEY,
+    event_id TEXT NOT NULL,
+    payment_id TEXT NOT NULL,
+    simplex_event_status TEXT NOT NULL,
+    simplex_payment_status TEXT,
+    partner_id TEXT,
+    partner_end_user_id TEXT,
+    crypto_currency TEXT,
+    fiat_total_amount NUMERIC,
+    fiat_total_amount_currency TEXT,
+    crypto_total_amount NUMERIC,
+    crypto_total_amount_currency TEXT,
+    payment_created_at TIMESTAMP WITHOUT TIME ZONE,
+    payment_updated_at TIMESTAMP WITHOUT TIME ZONE,
+    event_timestamp TIMESTAMP WITHOUT TIME ZONE
+);
+
+CREATE INDEX ON simplex_payment_event(event_id);
+CREATE INDEX ON simplex_payment_event(payment_id);
+
+COMMIT;
+
+-- ==== DOWN ====
+
+BEGIN;
+
+DROP TABLE simplex_payment_event;
+
+COMMIT;


### PR DESCRIPTION
Normally we deleted payment result events through simplex-api. Because They said that we must clean events from get all events endpoint. If we delete events we could not reach result of payment if we need this data. So We can save payment event result to our database.   