### PR TITLE
store-api: bugfix, some API returned timestamp fields were in ISO

### DIFF
--- a/store-api-server/src/payment/service/payment.service.ts
+++ b/store-api-server/src/payment/service/payment.service.ts
@@ -306,7 +306,7 @@ WHERE nft_order.id = $1
       id: orderId,
       userId: qryRes.rows[0]['user_id'],
       userAddress: qryRes.rows[0]['user_address'],
-      expiresAt: qryRes.rows[0]['expires_at'],
+      expiresAt: qryRes.rows[0]['expires_at'].getTime(),
       nfts: await this.nftService.findByIds(
         qryRes.rows.map((row: any) => row['nft_id']),
         undefined,

--- a/store-api-server/src/user/service/user.service.ts
+++ b/store-api-server/src/user/service/user.service.ts
@@ -508,7 +508,7 @@ RETURNING id, expires_at`,
       );
       return {
         id: qryRes.rows[0]['id'],
-        expiresAt: qryRes.rows[0]['expires_at'],
+        expiresAt: qryRes.rows[0]['expires_at'].getTime(),
       };
     } catch (err: any) {
       if (err?.code === PG_UNIQUE_VIOLATION_ERRCODE) {
@@ -553,7 +553,7 @@ ORDER BY expires_at DESC
     }
     return <CartMeta>{
       id: qryRes.rows[0]['id'],
-      expiresAt: qryRes.rows[0]['expires_at'],
+      expiresAt: qryRes.rows[0]['expires_at'].getTime(),
       orderId: qryRes.rows[0]['order_id'],
     };
   }

--- a/store-api-server/test/app.e2e.spec.ts
+++ b/store-api-server/test/app.e2e.spec.ts
@@ -3246,6 +3246,7 @@ describe('AppController (e2e)', () => {
     delete paymentIntentRes.body.paymentDetails.mutezAmount;
     expect(Number(paymentIntentRes.body.amount)).toBeGreaterThan(0);
     delete paymentIntentRes.body.amount;
+    expect(typeof paymentIntentRes.body.expiresAt).toBe('number');
     delete paymentIntentRes.body.expiresAt;
     for (const i in paymentIntentRes.body.nfts) {
       expect(Number(paymentIntentRes.body.nfts[i].price)).toBeGreaterThan(0);
@@ -3480,6 +3481,7 @@ describe('AppController (e2e)', () => {
     const cartBefore = await request(app.getHttpServer())
       .get('/users/cart/list')
       .set('authorization', bearer);
+    expect(typeof cartBefore.body.expiresAt).toBe('number');
     delete cartBefore.body.expiresAt;
     for (const i in cartBefore.body.nfts) {
       expect(cartBefore.body.nfts[i].createdAt).toBeGreaterThan(0);


### PR DESCRIPTION
They should be instead in UNIX seconds