### PR TITLE
Admin api test fixes

### DIFF
--- a/admin-api-server/script/test
+++ b/admin-api-server/script/test
@@ -47,6 +47,11 @@ rm $sig_err_file
     yarn build || exit 1
 ) &
 (
+    cd "$SCRIPT_DIR/../../store-api-server"
+
+    yarn install
+) &
+(
     trap "echo 'db setup failed..' >> $sig_err_file" ERR
 
     echo "waiting for testdb setup (admin).. (docker: $db_docker)"

--- a/admin-api-server/script/test
+++ b/admin-api-server/script/test
@@ -38,18 +38,16 @@ rm $sig_err_file
 
     echo "ensuring up to date build w/ yarn linked deps (api-lib, etc)..."
     ./script/build-deps || exit 1
+    yarn build
 ) &
 (
     trap "echo 'store build failed' >> $sig_err_file" ERR
 
     cd $SCRIPT_DIR/../../store-api-server;
-    ./script/build-deps >/dev/null 2>&1 || exit 1
-    yarn build || exit 1
-) &
-(
-    cd "$SCRIPT_DIR/../../store-api-server"
 
     yarn install
+    ./script/build-deps >/dev/null 2>&1 || exit 1
+    yarn build || exit 1
 ) &
 (
     trap "echo 'db setup failed..' >> $sig_err_file" ERR

--- a/config/.env-kanvas
+++ b/config/.env-kanvas
@@ -1,3 +1,3 @@
-export NODE_URL=https://ghostnet-archive.tzconnect.berlin
+export NODE_URL=https://ghostnet.tezos.marigold.dev/
 export DATABASE_URL="host=localhost dbname=postgres user=postgres password=passw0rd port=5431"
 export BCD_NETWORK=ghostnet

--- a/store-api-server/package.json
+++ b/store-api-server/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "nest build",
-    "preinstall": "echo PREINSTALL EXISTS; git submodule update --init",
+    "preinstall": "git submodule update --init",
     "postinstall": "yarn run patch-package; ./script/build-deps",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",

--- a/store-api-server/package.json
+++ b/store-api-server/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "nest build",
+    "preinstall": "echo PREINSTALL EXISTS; git submodule update --init",
     "postinstall": "yarn run patch-package; ./script/build-deps",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",


### PR DESCRIPTION
in a freshly cloned kanvas repo:

expected: a `yarn install` followed by `yarn test` in admin-api-server/ should run the tests correctly.

bug: this would fail, because store-api-server was expected to be already yarn installed (flawed expectation)

fix: do a `yarn install` of the store-api-server in the script/test setup