### PR TITLE
Attempt fix so types can be used in FE

### DIFF
--- a/store-api-server/src/payment/entity/payment.entity.ts
+++ b/store-api-server/src/payment/entity/payment.entity.ts
@@ -7,6 +7,8 @@ export enum OrderStatus {
   DELIVERED = 'delivered',
 }
 
+export type OrderStatusString =  `${OrderStatus}`
+
 export enum NftDeliveryStatus {
   UNKNOWN = 'unknown',
   INITIATING = 'initiating',
@@ -14,8 +16,10 @@ export enum NftDeliveryStatus {
   DELIVERED = 'delivered',
 }
 
+export type OrderStatusStringString =  `${NftDeliveryStatus}`
+
 export interface NftDeliveryInfo {
-  status: NftDeliveryStatus;
+  status: OrderStatusStringString;
   transferOpHash?: string;
   proxiedNft?: NftEntity;
 }
@@ -23,11 +27,11 @@ export interface NftDeliveryInfo {
 export interface OrderInfo {
   orderedNfts: NftEntity[];
 
-  orderStatus: OrderStatus;
+  orderStatus: OrderStatusString;
   paymentIntents: {
     paymentId: string;
     provider: PaymentProvider;
-    status: PaymentStatus;
+    status: PaymentStatusString;
   }[];
 
   delivery?: {
@@ -44,6 +48,8 @@ export enum PaymentStatus {
   PROCESSING = 'processing',
   SUCCEEDED = 'succeeded',
 }
+
+export type PaymentStatusString =  `${PaymentStatus}`
 
 export interface StripeDetails {
   clientSecret: string;


### PR DESCRIPTION
The issue is that - in FE code - we cannot import actual values. We can only `import type`. The reason is that we only have source code available to us. Here is an e.g. of an import we make:

```ts
import type { OrderInfo } from "kanvas/store-api-server/src/payment/entity/payment.entity";
```

This imports types from Typescript source code.

The problem (which has happened before) - is that FE code cannot import values e.g. enums which can be used as both types or values. So we can e.g.

```ts
import type { OrderStatus } from "kanvas/store-api-server/src/payment/entity/payment.entity";
```

But we cannot:

```ts
import { OrderStatus } from "kanvas/store-api-server/src/payment/entity/payment.entity";
```

The latter is importing as a value. If other types, e.g. `OrderInfo` are defined in terms of `enum` values, e.g.

```ts
export interface OrderInfo {
  orderStatus: OrderStatus;
// ...
}
```

Then we immediately have a problem on the FE side because we cannot create values of type `OrderStatus` because we cannot import `OrderStatus` as a value (as the JS generated from TS) - because we only have access to TS code.

One solution (i.e. one that does not create a separate module that actually transpiles these TS types and is installable in many places) - is to define types in terms of only TS types - stuff which gets removed after TS compilation anyway and is intended only for compilation purposes - not runtime.

This PR provides such a solution by creating an alternate string subset type for each enum type and using the string version instead of the enum when defining types which FE needs to create / read / interact with.

This keeps IDE support ... i.e. intellisense will suggest valid strings only... and will catch invalid types in IDE. Most importantly, it does not require FE to import enums as values.