### PR TITLE
created_at column in marketing table + replicate marketing to admin-db

### DIFF
--- a/store-api-server/migrations/1669027039-marketing-timestamped.sql
+++ b/store-api-server/migrations/1669027039-marketing-timestamped.sql
@@ -1,0 +1,17 @@
+-- Migration: marketing-timestamped
+-- Created at: 2022-11-21 11:37:19
+-- ====  UP  ====
+
+BEGIN;
+
+ALTER TABLE marketing ADD COLUMN created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT (now() AT TIME ZONE 'UTC');
+
+COMMIT;
+
+-- ==== DOWN ====
+
+BEGIN;
+
+ALTER TABLE marketing DROP COLUMN created_at;
+
+COMMIT;

--- a/store-api-server/migrations/1669027753-replicate-marketing.sql
+++ b/store-api-server/migrations/1669027753-replicate-marketing.sql
@@ -1,0 +1,17 @@
+-- Migration: replicate-marketing
+-- Created at: 2022-11-21 11:49:13
+-- ====  UP  ====
+
+BEGIN;
+
+ALTER PUBLICATION store_pub ADD TABLE marketing;
+
+COMMIT;
+
+-- ==== DOWN ====
+
+BEGIN;
+
+ALTER PUBLICATION store_pub DROP TABLE marketing;
+
+COMMIT;

--- a/store-api-server/test/isolated.e2e.ts
+++ b/store-api-server/test/isolated.e2e.ts
@@ -441,7 +441,7 @@ SELECT
         await testUtils.withDbConn(async (db) => {
           expect(
             (await db.query('SELECT * FROM marketing')).rows,
-          ).toStrictEqual([
+          ).toMatchObject([
             {
               id: 1,
               address: walletAddress,
@@ -475,7 +475,7 @@ SELECT
         await testUtils.withDbConn(async (db) => {
           expect(
             (await db.query('SELECT * FROM marketing')).rows,
-          ).toStrictEqual([
+          ).toMatchObject([
             {
               id: 1,
               address: walletAddress,


### PR DESCRIPTION
we need the marketing table in the admin-api for user analytics