### PR TITLE
Admin-api entrypoint: replication setup simplification

### DIFF
--- a/admin-api-server/Dockerfile
+++ b/admin-api-server/Dockerfile
@@ -32,12 +32,6 @@ RUN addgroup --system --gid 1001 nodejs && \
 USER nodejs
 WORKDIR /build
 
-# these are added to allow the admin-api to check whether the store-db
-# has finished it's setup (whether all migrations have been applied),
-# before continuing with subscribing to the replication subscription
-ADD --chown=nodejs:nodejs store-api-server/script/shmig /store-api-server/script/shmig
-ADD --chown=nodejs:nodejs store-api-server/migrations /store-api-server/migrations
-
 COPY --chown=nodejs:nodejs --from=build /build/result/ .
 COPY --chown=nodejs:nodejs --from=build /lib /lib
 

--- a/admin-api-server/script/entrypoint
+++ b/admin-api-server/script/entrypoint
@@ -2,11 +2,25 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR/..
 
+set -x
+
 INIT_QUEPASA=false script/migrate || exit 1
 
-if [[ "`psql -c \"select count(1) from kanvas_user\" -tA`" == "0" ]]; then
-    yarn seed
-    script/setup-replication-sub
+QRY_NUM_KANVAS_USERS="SELECT COUNT(1) FROM kanvas_user"
+if [[ "`psql -c \"$QRY_NUM_KANVAS_USERS\" -tA`" == "0" ]]; then
+    yarn seed || exit 1
+fi
+
+QRY_NUM_STORE_SUB="SELECT count(1) FROM pg_subscription WHERE subname = 'store_sub'"
+QRY_NUM_STORE_SUB_WORKERS="SELECT count(1) FROM pg_stat_subscription WHERE subname = 'store_sub' AND pid IS NOT NULL"
+if [[ "`psql -c \"$QRY_NUM_STORE_SUB\" -tA`" == "0" ]]; then
+    script/setup-replication-sub || exit 1
+elif [[ "`psql -c \"$QRY_NUM_STORE_SUB_WORKERS\" -tA`" == "0" ]]; then
+    # this happens (an inactive store_sub subscription) when there has been a
+    # schema change in one of the replicated tables in the store db, we solve
+    # this here in a simple way where we drop the replication schema and then
+    # recreate it
+    script/resetup-replication-sub || exit 1
 fi
 
 node dist/src/main.js

--- a/admin-api-server/script/resetup-replication-sub
+++ b/admin-api-server/script/resetup-replication-sub
@@ -2,19 +2,21 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR
 
-set -a
-. ../.env
-set +a
+PGDATABASE=store_replication psql -c '
+BEGIN;
 
-function msg_wait {
-    echo "$@ (press any button to proceed, or ^C to stop)"
-    read -s -n 1
-}
+DROP SCHEMA onchain_kanvas CASCADE;
 
-msg_wait 'please make sure que-pasa is not running. if it is, stop it before proceeding here..' || exit 1
+-- dropping the following set of schemas in case they exist, they might if the
+-- admin quepasa was started with the same que pasa config as the store quepasa
+DROP SCHEMA IF EXISTS paypoint CASCADE;
+DROP SCHEMA IF EXISTS token_gate CASCADE;
 
+DROP SCHEMA que_pasa CASCADE;
+DROP SCHEMA public CASCADE;
+CREATE SCHEMA public;
+
+COMMIT;' || exit 1
 PGDATABASE=store_replication psql -c 'DROP SUBSCRIPTION store_sub' || exit 1
-psql -c 'drop database store_replication' || exit 1
-psql -c 'create database store_replication' || exit 1
 
 ./setup-replication-sub

--- a/admin-api-server/script/setup-replication-sub
+++ b/admin-api-server/script/setup-replication-sub
@@ -2,22 +2,6 @@
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 cd $SCRIPT_DIR
 
-echo waiting for subscription target database to be up..
-(
-    export PGUSER=$STORE_PGUSER
-    export PGPASSWORD=$STORE_PGPASSWORD
-    export PGDATABASE=$STORE_PGDATABASE
-    export PGHOST=$STORE_PGHOST
-    export PGPORT=$STORE_PGPORT
-    ./wait-db
-
-    cd $SCRIPT_DIR/../../store-api-server
-    while [ "`HOST=$PGHOST PORT=$PGPORT LOGIN=$PGUSER PASSWORD=$PGPASSWORD ./script/shmig -t postgresql -d $PGDATABASE pending`" != "" ]; do
-        echo store pub not ready yet..
-        sleep 1
-    done
-)
-
 # must copy over table, enum definitions, etc first. Otherwise the
 # subscription will not work (it will not bring over these definitions, unfortunately)
 

--- a/config/.env-kanvas
+++ b/config/.env-kanvas
@@ -1,3 +1,3 @@
-export NODE_URL=https://ghostnet.tezos.marigold.dev/
+export NODE_URL=https://ghostnet-archive.tzconnect.berlin
 export DATABASE_URL="host=localhost dbname=postgres user=postgres password=passw0rd port=5431"
 export BCD_NETWORK=ghostnet

--- a/store-api-server/script/entrypoint
+++ b/store-api-server/script/entrypoint
@@ -5,7 +5,7 @@ cd $SCRIPT_DIR/..
 INIT_QUEPASA=false script/migrate || exit 1
 
 if [[ '`psql -c \"select count(1) from kanvas_user\" -tA`' != '0' ]]; then 
-    psql -c 'ALTER USER replication_user REPLICATION'
+    psql -c "ALTER USER $PGUSER REPLICATION"
     psql < script/populate-stagingdb.sql
 fi
 


### PR DESCRIPTION
Simplify the replication setup such that it doesn't use a `wait-db` construct or a double check that the store-db has all store migration steps applied. Simply rely on a retry mechanism, ie err in case one of these conditions don't hold. This also allowed simplifiying the Dockerfile of the admin-api-server, because we no longer need to have the store migration files loaded into the docker image.

Additionally, improved reliability of replication setup by not relying on an empty kanvas_user table for it to be triggered. Instead, query the admin database for the state of the replication subscription;
- if no replication subscription exists, trigger the replication setup script
- if a replication subscription exists, but it has 0 active workers, this means the replication broke due to a schema change in the store database, in this case trigger the replication resetup script