### PR TITLE
Fix use reserved name for PGUSER in Entrypoint

### DIFF
--- a/gcp-build-mu-staging.sh
+++ b/gcp-build-mu-staging.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# # store-backend
+# docker build -f store-api-server/Dockerfile --platform linux/amd64 -t europe-west1-docker.pkg.dev/tz-mu-staging/mu-staging/mu-staging-backend .
+# docker push europe-west1-docker.pkg.dev/tz-mu-staging/mu-staging/mu-staging-backend
+
+# # store-frontend
+# docker build -f store-frontend/Dockerfile --platform linux/amd64 -t europe-west1-docker.pkg.dev/tz-mu-staging/mu-staging/mu-staging-frontend .
+# docker push europe-west1-docker.pkg.dev/tz-mu-staging/mu-staging/mu-staging-frontend
+
+# # admin-backend
+# docker build -f admin-api-server/Dockerfile --platform linux/amd64 -t europe-west1-docker.pkg.dev/tz-mu-staging/mu-staging/mu-staging-admin-backend .
+# docker push europe-west1-docker.pkg.dev/tz-mu-staging/mu-staging/mu-staging-admin-backend
+
+# admin-frontend
+docker build -f admin-front/Dockerfile --platform linux/amd64 \
+             -t europe-west1-docker.pkg.dev/tz-mu-staging/mu-staging/mu-staging-admin-frontend \
+             --build-arg REACT_APP_STORE_API_URL=https://mu-staging.tzconnect.berlin/api \
+             --build-arg REACT_APP_API_SERVER_BASE_URL=https://mu-staging-admin.tzconnect.berlin/api \
+             --build-arg REACT_APP_STORE_BASE_URL=https://mu-staging.tzconnect.berlin .
+docker push europe-west1-docker.pkg.dev/tz-mu-staging/mu-staging/mu-staging-admin-frontend

--- a/gcp-build-staging.sh
+++ b/gcp-build-staging.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# store-backend
+docker build -f store-api-server/Dockerfile --platform linux/amd64 -t europe-west1-docker.pkg.dev/tz-sowvital-staging/sowvital-staging/sowvital-staging-backend .
+docker push europe-west1-docker.pkg.dev/tz-sowvital-staging/sowvital-staging/sowvital-staging-backend
+
+# # store-frontend
+# docker build -f store-frontend/Dockerfile --platform linux/amd64 -t europe-west1-docker.pkg.dev/tz-sowvital-staging/sowvital-staging/sowvital-staging-frontend .
+# docker push europe-west1-docker.pkg.dev/tz-sowvital-staging/sowvital-staging/sowvital-staging-frontend
+
+# admin-backend
+docker build -f admin-api-server/Dockerfile --platform linux/amd64 -t europe-west1-docker.pkg.dev/tz-sowvital-staging/sowvital-staging/sowvital-staging-admin-backend .
+docker push europe-west1-docker.pkg.dev/tz-sowvital-staging/sowvital-staging/sowvital-staging-admin-backend
+
+# # admin-frontend
+# docker build -f admin-front/Dockerfile --platform linux/amd64 \
+#              -t europe-west1-docker.pkg.dev/tz-sowvital-staging/sowvital-staging/sowvital-staging-admin-frontend \
+#              --build-arg REACT_APP_API_SERVER_BASE_URL=https://sowvital-admin-staging.tzconnect.berlin/api \
+#              --build-arg REACT_APP_STORE_BASE_URL=https://sowvital-staging.tzconnect.berlin .
+# docker push europe-west1-docker.pkg.dev/tz-sowvital-staging/sowvital-staging/sowvital-staging-admin-frontend

--- a/gcp-build.sh
+++ b/gcp-build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker build -f store-api-server/Dockerfile --platform linux/amd64 -t europe-west1-docker.pkg.dev/sowvital/sowvital/sowvital-store-backend .
+docker push europe-west1-docker.pkg.dev/sowvital/sowvital/sowvital-store-backend

--- a/store-api-server/script/entrypoint
+++ b/store-api-server/script/entrypoint
@@ -9,7 +9,7 @@ if [[ '`psql -c \"select count(1) from nft_category\" -tA`' == '0' ]]; then
 fi
 
 if [[ "`psql -c \"SELECT rolreplication FROM pg_roles WHERE rolname = '$PGUSER'\" -tA`" == 'f' ]]; then
-    psql -c "ALTER USER $PGUSER REPLICATION"
+    psql -c "ALTER USER \"$PGUSER\" REPLICATION"
 fi
 
 node dist/src/main.js


### PR DESCRIPTION
It is now possible to grant replication permission to the PGUSER even if the PGUSER is reserved word.