### PR TITLE
prevent admin replication setup script from logging errors on pg_restore

### DIFF
--- a/admin-api-server/script/entrypoint
+++ b/admin-api-server/script/entrypoint
@@ -14,13 +14,13 @@ fi
 QRY_NUM_STORE_SUB="SELECT count(1) FROM pg_subscription WHERE subname = 'store_sub'"
 QRY_NUM_STORE_SUB_WORKERS="SELECT count(1) FROM pg_stat_subscription WHERE subname = 'store_sub' AND pid IS NOT NULL"
 if [[ "`psql -c \"$QRY_NUM_STORE_SUB\" -tA`" == "0" ]]; then
-    script/setup-replication-sub || exit 1
+    script/setup-replication-sub &
 elif [[ "`psql -c \"$QRY_NUM_STORE_SUB_WORKERS\" -tA`" == "0" ]]; then
     # this happens (an inactive store_sub subscription) when there has been a
     # schema change in one of the replicated tables in the store db, we solve
     # this here in a simple way where we drop the replication schema and then
     # recreate it
-    script/resetup-replication-sub || exit 1
+    script/resetup-replication-sub &
 fi
 
 node dist/src/main.js

--- a/admin-api-server/script/entrypoint
+++ b/admin-api-server/script/entrypoint
@@ -14,13 +14,13 @@ fi
 QRY_NUM_STORE_SUB="SELECT count(1) FROM pg_subscription WHERE subname = 'store_sub'"
 QRY_NUM_STORE_SUB_WORKERS="SELECT count(1) FROM pg_stat_subscription WHERE subname = 'store_sub' AND pid IS NOT NULL"
 if [[ "`psql -c \"$QRY_NUM_STORE_SUB\" -tA`" == "0" ]]; then
-    script/setup-replication-sub &
+    script/setup-replication-sub || exit 1
 elif [[ "`psql -c \"$QRY_NUM_STORE_SUB_WORKERS\" -tA`" == "0" ]]; then
     # this happens (an inactive store_sub subscription) when there has been a
     # schema change in one of the replicated tables in the store db, we solve
     # this here in a simple way where we drop the replication schema and then
     # recreate it
-    script/resetup-replication-sub &
+    script/resetup-replication-sub || exit 1
 fi
 
 node dist/src/main.js

--- a/admin-api-server/script/setup-replication-sub
+++ b/admin-api-server/script/setup-replication-sub
@@ -8,12 +8,16 @@ cd $SCRIPT_DIR
 store_schema_file=`mktemp`
 PGPASSWORD=$STORE_PGPASSWORD pg_dump --host=$STORE_PGHOST --port=$STORE_PGPORT --dbname=$STORE_PGDATABASE --username=$STORE_PGUSER --schema-only --format c --no-privileges --no-owner > $store_schema_file
 
-pg_restore --no-publications --schema=public --host=$PGHOST --port=$PGPORT --username=$PGUSER --schema-only --clean --dbname=store_replication < $store_schema_file
+PGDATABASE=store_replication psql -c "
+  CREATE SCHEMA IF NOT EXISTS peppermint;
+" || exit 1
+
+pg_restore --no-publications --schema=public --schema=peppermint --host=$PGHOST --port=$PGPORT --username=$PGUSER --schema-only --no-owner --clean --if-exists --dbname=store_replication < $store_schema_file || exit 1
 
 PGDATABASE=store_replication psql -c "
     CREATE SUBSCRIPTION store_sub
     CONNECTION 'host=$STORE_PGHOST port=$STORE_PGPORT dbname=$STORE_PGDATABASE user=$STORE_PGUSER password=$STORE_PGPASSWORD'
     PUBLICATION store_pub;
-"
+" || exit 1
 
 ./db_procedures

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - 3005:3000
     links:
       - store-db
+      - store-quepasa
     environment:
       PGHOST: store-db
       PGPORT: 5432
@@ -133,6 +134,7 @@ services:
       - 3006:3001
     links:
       - admin-db
+      - admin-quepasa
       - store-db
       - store-api
     env_file:


### PR DESCRIPTION
Gets rid of the very noisy logs of the replication setup